### PR TITLE
ENH: set build_fn default values as model parameters

### DIFF
--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import random
 import warnings
@@ -157,3 +158,12 @@ def get_metric_full_name(name: str) -> str:
         # may be passed "loss" from thre training history
         return name
     return getattr(deserialize_metric(name), "__name__")
+
+
+def _get_default_args(func):
+    signature = inspect.signature(func)
+    return {
+        k: v.default
+        for k, v in signature.parameters.items()
+        if v.default is not inspect.Parameter.empty
+    }

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -29,9 +29,9 @@ from tensorflow.python.keras.utils.generic_utils import (
 
 from ._utils import LabelDimensionTransformer
 from ._utils import TFRandomState
+from ._utils import _get_default_args
 from ._utils import get_metric_full_name
 from ._utils import make_model_picklable
-from ._utils import _get_default_args
 
 
 # known keras function names that will be added to _legal_params_fns if they

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -31,6 +31,7 @@ from ._utils import LabelDimensionTransformer
 from ._utils import TFRandomState
 from ._utils import get_metric_full_name
 from ._utils import make_model_picklable
+from ._utils import _get_default_args
 
 
 # known keras function names that will be added to _legal_params_fns if they
@@ -124,8 +125,10 @@ class BaseWrapper(BaseEstimator):
 
         self.build_fn = build_fn
 
-        if sk_params:
+        kwargs = _get_default_args(build_fn) if inspect.isfunction(build_fn) else {}
+        sk_params = {**kwargs, **sk_params}
 
+        if sk_params:
             # for backwards compatibility
 
             # the sklearn API requires that all __init__ parameters be saved

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -125,7 +125,7 @@ class BaseWrapper(BaseEstimator):
 
         self.build_fn = build_fn
 
-       if inspect.isfunction(build_fn):
+        if inspect.isfunction(build_fn):
             kwargs = _get_default_args(build_fn)
             sk_params = {**kwargs, **sk_params}
 

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -125,10 +125,9 @@ class BaseWrapper(BaseEstimator):
 
         self.build_fn = build_fn
 
-        kwargs = (
-            _get_default_args(build_fn) if inspect.isfunction(build_fn) else {}
-        )
-        sk_params = {**kwargs, **sk_params}
+       if inspect.isfunction(build_fn):
+            kwargs = _get_default_args(build_fn)
+            sk_params = {**kwargs, **sk_params}
 
         if sk_params:
             # for backwards compatibility

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -125,7 +125,9 @@ class BaseWrapper(BaseEstimator):
 
         self.build_fn = build_fn
 
-        kwargs = _get_default_args(build_fn) if inspect.isfunction(build_fn) else {}
+        kwargs = (
+            _get_default_args(build_fn) if inspect.isfunction(build_fn) else {}
+        )
         sk_params = {**kwargs, **sk_params}
 
         if sk_params:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -64,7 +64,7 @@ BATCH_SIZE = 5
 EPOCHS = 1
 
 
-def build_fn_clf(hidden_dim):
+def build_fn_clf(hidden_dim=HIDDEN_DIM):
     """Builds a Sequential based classifier."""
     model = keras.models.Sequential()
     model.add(keras.layers.Dense(INPUT_DIM, input_shape=(INPUT_DIM,)))
@@ -1552,3 +1552,8 @@ class TestPackUnpack:
             pack_keras_model(obj, 0)
         with pytest.raises(TypeError):
             unpack_keras_model(obj, 0)
+
+
+def test_build_fn_default_params():
+    est = wrappers.KerasClassifier(build_fn=build_fn_clf)
+    assert "hidden_dim" in est.get_params()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1559,6 +1559,8 @@ def test_build_fn_default_params():
     params = est.get_params()
     assert params["hidden_dim"] == HIDDEN_DIM
 
-    est = wrappers.KerasClassifier(build_fn=build_fn_clf, hidden_dim=HIDDEN_DIM + 1)
+    est = wrappers.KerasClassifier(
+        build_fn=build_fn_clf, hidden_dim=HIDDEN_DIM + 1
+    )
     params = est.get_params()
     assert params["hidden_dim"] == HIDDEN_DIM + 1

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1556,4 +1556,9 @@ class TestPackUnpack:
 
 def test_build_fn_default_params():
     est = wrappers.KerasClassifier(build_fn=build_fn_clf)
-    assert "hidden_dim" in est.get_params()
+    params = est.get_params()
+    assert params["hidden_dim"] == HIDDEN_DIM
+
+    est = wrappers.KerasClassifier(build_fn=build_fn_clf, hidden_dim=HIDDEN_DIM + 1)
+    params = est.get_params()
+    assert params["hidden_dim"] == HIDDEN_DIM + 1

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1555,6 +1555,9 @@ class TestPackUnpack:
 
 
 def test_build_fn_default_params():
+    """Tests that default arguments arguments of 
+    `build_fn` are registered as hyperparameters.
+    """
     est = wrappers.KerasClassifier(build_fn=build_fn_clf)
     params = est.get_params()
     assert params["hidden_dim"] == HIDDEN_DIM


### PR DESCRIPTION
**What does this PR implement?**
It set default values of `build_fn` to be model parameters. This means model selection searches mirror the Scikit-learn interface.

This PR makes this search possible:

``` python
def build_fn(solver="sgd"):
    ...
    model.compile(optimizer="sgd", ...)
    return model

params = {"solver": ["sgd", "adam"]}
model = wrappers.KerasClassifier(build_fn, epochs=2)
assert "solver" in model.get_params()
search = GridSearchCV(model, params)
search.fit(*mnist())
```

This almost exactly mirrors this Scikit-learn example:

``` python
from sklearn.datasets import make_classification
from sklearn.model_selection import GridSearchCV
from sklearn.neural_network import MLPClassifier

X, y = make_classification()
params = {"solver": ["sgd", "adam"]}
model = MLPClassifier(max_iter=2)
assert "solver" in model.get_params()
search = GridSearchCV(model, params)
search.fit(X, y)
```

**Reference issues/PRs**
This resolves #18.