### PR TITLE
BUG: Normalize loss metric names

### DIFF
--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -2,3 +2,14 @@
 
 __author__ = """Adrian Garcia Badaracco"""
 __version__ = "0.1.8"
+
+
+# Monkey patch log_cosh reference
+# See https://github.com/tensorflow/tensorflow/pull/42097
+# Will be removed whenever the
+# min supported version of tf incorporates the fix
+import tensorflow.python.keras.metrics  # noqa
+
+tensorflow.python.keras.metrics.log_cosh = (
+    tensorflow.python.keras.metrics.logcosh
+)

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -136,7 +136,7 @@ def make_model_picklable(model_obj):
     model_obj.__reduce_ex__ = pack_keras_model.__get__(model_obj)
 
 
-def get_loss_metric_full_name(name: str) -> str:
+def get_metric_full_name(name: str) -> str:
     """Get aliases for Keras losses and metrics.
 
     See: https://github.com/tensorflow/tensorflow/pull/42097

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -105,6 +105,7 @@ def pack_keras_model(model_obj, protocol):
     Pickled model
         A tuple following the pickle protocol.
     """
+
     if not isinstance(model_obj, Model):
         raise TypeError("`model_obj` must be an instance of a Keras Model")
     # pack up model
@@ -137,7 +138,7 @@ def get_loss_metric_full_name(name: str) -> str:
     See:
     https://github.com/tensorflow/tensorflow/blob/b36436b087bd8e8701ef51718179037cccdfc26e/tensorflow/python/keras/metrics.py#L3392
     https://github.com/tensorflow/tensorflow/blob/d9ea5051104b3580fee2d49c94be2ec45012672f/tensorflow/python/keras/losses.py#L1799
-    """ # noqa
+    """  # noqa
     mapping = {
         "acc": "accuracy",
         "bce": "binary_crossentropy",

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -140,7 +140,7 @@ def get_loss_metric_full_name(name: str) -> str:
     """Get aliases for Keras losses and metrics.
 
     See: https://github.com/tensorflow/tensorflow/pull/42097
-    """  # noqa
+    """
     # deserialize returns the actual function, then get it's name
     # to keep a single consistent name for the metric
     return getattr(deserialize_metric(name), __name__)

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 import tensorflow as tf
 from tensorflow.keras.layers import (
     deserialize as deserialize_layer,
-    serialize as serialize_layer
+    serialize as serialize_layer,
 )
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.saving import saving_utils
@@ -153,4 +153,7 @@ def get_metric_full_name(name: str) -> str:
     """
     # deserialize returns the actual function, then get it's name
     # to keep a single consistent name for the metric
-    return getattr(deserialize_metric(name), __name__)
+    if name == "loss":
+        # may be passed "loss" from thre training history
+        return name
+    return getattr(deserialize_metric(name), "__name__")

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -129,3 +129,33 @@ def make_model_picklable(model_obj):
     if not isinstance(model_obj, Model):
         raise TypeError("`model_obj` must be an instance of a Keras Model")
     model_obj.__reduce_ex__ = pack_keras_model.__get__(model_obj)
+
+
+def get_loss_metric_full_name(name: str) -> str:
+    """Aliases for Keras losses and metrics.
+
+    See:
+    https://github.com/tensorflow/tensorflow/blob/b36436b087bd8e8701ef51718179037cccdfc26e/tensorflow/python/keras/metrics.py#L3392
+    https://github.com/tensorflow/tensorflow/blob/d9ea5051104b3580fee2d49c94be2ec45012672f/tensorflow/python/keras/losses.py#L1799
+    """ # noqa
+    mapping = {
+        "acc": "accuracy",
+        "bce": "binary_crossentropy",
+        "mse": "mean_square_error",
+        "mean_squared_error": "mean_square_error",
+        "mae": "mean_absolute_error",
+        "mape": "mean_absolute_percentage_error",
+        "msle": "mean_squared_logarithmic_error",
+        "cosine_similarity": "cosine_proximity",
+        "kld": "kl_divergence",
+        "kullback_leibler_divergence": "kl_divergence",
+        "logcosh": "log_cosh",
+        "huber_loss": "huber",
+    }
+    if name.lower() in mapping.keys():
+        return mapping[name.lower()]
+    if name.lower() in mapping.values():
+        return name.lower()
+    if name == "loss":
+        return name
+    raise ValueError(f"Unknonw loss/metric '{name}'")

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -140,6 +140,16 @@ def get_loss_metric_full_name(name: str) -> str:
     """Get aliases for Keras losses and metrics.
 
     See: https://github.com/tensorflow/tensorflow/pull/42097
+
+    Parameters
+    ----------
+    name : str
+        Full name or shorthand for Keras metric. Ex: "mse".
+
+    Returns
+    -------
+    str
+        Full name for Keras metric. Ex: "mean_squared_error".
     """
     # deserialize returns the actual function, then get it's name
     # to keep a single consistent name for the metric

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -331,18 +331,13 @@ class BaseWrapper(BaseEstimator):
             hist = self.model_.fit(x=X, y=y, **fit_args)
 
         if warm_start:
-            try:
-                if not hasattr(self, "history_"):
-                    self.history_ = defaultdict(list)
-                self.history_ = {
-                    get_metric_full_name(k): self.history_[
-                        get_metric_full_name(k)
-                    ]
-                    + hist.history[k]
-                    for k in hist.history.keys()
-                }
-            except:
-                pass
+            if not hasattr(self, "history_"):
+                self.history_ = defaultdict(list)
+            self.history_ = {
+                get_metric_full_name(k): self.history_[get_metric_full_name(k)]
+                + hist.history[k]
+                for k in hist.history.keys()
+            }
         else:
             self.history_ = hist.history
         self.is_fitted_ = True

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -335,7 +335,10 @@ class BaseWrapper(BaseEstimator):
                 if not hasattr(self, "history_"):
                     self.history_ = defaultdict(list)
                 self.history_ = {
-                    get_loss_metric_full_name(k): self.history_[get_loss_metric_full_name(k)] + hist.history[k]
+                    get_loss_metric_full_name(k): self.history_[
+                        get_loss_metric_full_name(k)
+                    ]
+                    + hist.history[k]
                     for k in hist.history.keys()
                 }
             except:

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -29,6 +29,7 @@ from ._utils import (
     TFRandomState,
     LabelDimensionTransformer,
     make_model_picklable,
+    get_loss_metric_full_name,
 )
 
 
@@ -330,12 +331,15 @@ class BaseWrapper(BaseEstimator):
             hist = self.model_.fit(x=X, y=y, **fit_args)
 
         if warm_start:
-            if not hasattr(self, "history_"):
-                self.history_ = defaultdict(list)
-            keys = set(hist.history).union(self.history_.keys())
-            self.history_ = {
-                k: self.history_[k] + hist.history[k] for k in keys
-            }
+            try:
+                if not hasattr(self, "history_"):
+                    self.history_ = defaultdict(list)
+                self.history_ = {
+                    get_loss_metric_full_name(k): self.history_[get_loss_metric_full_name(k)] + hist.history[k]
+                    for k in hist.history.keys()
+                }
+            except:
+                pass
         else:
             self.history_ = hist.history
         self.is_fitted_ = True

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -29,7 +29,7 @@ from ._utils import (
     TFRandomState,
     LabelDimensionTransformer,
     make_model_picklable,
-    get_loss_metric_full_name,
+    get_metric_full_name,
 )
 
 
@@ -335,8 +335,8 @@ class BaseWrapper(BaseEstimator):
                 if not hasattr(self, "history_"):
                     self.history_ = defaultdict(list)
                 self.history_ = {
-                    get_loss_metric_full_name(k): self.history_[
-                        get_loss_metric_full_name(k)
+                    get_metric_full_name(k): self.history_[
+                        get_metric_full_name(k)
                     ]
                     + hist.history[k]
                     for k in hist.history.keys()


### PR DESCRIPTION
The name of  metrics may change when a model goes through a serialize -> deserialize round trip. It is not enough to normalize the name when the model is serialized the first time, since the `history_` attribute may be initialized with keys before the first serialization.

The solution is to have a function that normalizes metric names to the full name and use that every time `history_` is updated so that `history_` has consistent keys.

This should resolve #34.