### PR TITLE
FIX: Update sample weight processing for future Scikit-Learn versions

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -233,13 +233,6 @@ class BaseWrapper(BaseEstimator):
         # get model arguments
         model_args = self._filter_params(final_build_fn)
 
-        # add `sample_weight` param
-        # while it is not usually needed to build the model, some Keras models
-        # require knowledge of the type of sample_weight to be built.
-        sample_weight_arg = self._filter_params(
-            final_build_fn, params_to_check={"sample_weight": sample_weight}
-        )
-
         # check if the model building function requires X and/or y to be passed
         X_y_args = self._filter_params(
             final_build_fn, params_to_check={"X": X, "y": y}
@@ -252,7 +245,6 @@ class BaseWrapper(BaseEstimator):
         build_args = {
             **model_args,  # noqa: E999
             **X_y_args,  # noqa: E999
-            **sample_weight_arg,  # noqa: E999
             **kwargs,  # noqa: E999
         }
 
@@ -309,12 +301,6 @@ class BaseWrapper(BaseEstimator):
 
         # filter kwargs down to those accepted by self.model_.fit
         kwargs = self._filter_params(self.model_.fit, params_to_check=kwargs)
-
-        if sample_weight is not None and "sample_weight" not in kwargs:
-            raise ValueError(
-                "Parameter `sample_weight` is unsupported by Keras model "
-                + str(self.model_)
-            )
 
         # get model.fit's arguments (allows arbitrary model use)
         fit_args = self._filter_params(self.model_.fit)
@@ -533,6 +519,17 @@ class BaseWrapper(BaseEstimator):
             sample_weight = _check_sample_weight(
                 sample_weight, X, dtype=["float64", "int"]
             )
+            # Scikit-Learn expects a 0 in sample_weight to mean
+            # "ignore the sample", but because of how Keras applies
+            # sample_weight to the loss function, this doesn't
+            # exacly work out (as in, sklearn estimator checks fail
+            # because the predictions differ by a small margin).
+            # To get around this, we manually delete these samples here
+            zeros = sample_weight == 0
+            if np.any(zeros):
+                X = X[~zeros]
+                y = y[~zeros]
+                sample_weight = sample_weight[~zeros]
 
         # pre process X, y
         X, _ = self._pre_process_X(X)

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -201,7 +201,7 @@ class BaseWrapper(BaseEstimator):
 
         return final_build_fn
 
-    def _fit_build_keras_model(self, X, y, sample_weight, **kwargs):
+    def _fit_build_keras_model(self, X, y, **kwargs):
         """Build the Keras model.
 
         This method will process all arguments and call the model building
@@ -213,8 +213,6 @@ class BaseWrapper(BaseEstimator):
                 and `n_features` is the number of features.
             y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
                 True labels for `X`.
-            sample_weight : array-like of shape (n_samples,)
-                Sample weights. The Keras Model must support this.
             **kwargs: dictionary arguments
                 Legal arguments are the arguments `build_fn`.
         Returns:
@@ -541,9 +539,7 @@ class BaseWrapper(BaseEstimator):
 
         # build model
         if (not warm_start) or (not hasattr(self, "model_")):
-            self.model_ = self._fit_build_keras_model(
-                X, y, sample_weight=sample_weight, **kwargs
-            )
+            self.model_ = self._fit_build_keras_model(X, y, **kwargs)
 
         y = self._check_output_model_compatibility(y)
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -626,12 +626,11 @@ class TestFullyCompliantWrappers:
 
     @parametrize_with_checks([FullyCompliantClassifier()])
     def test_fully_compliant_classifier(self, estimator, check):
-        if (
-            sklearn_version <= LooseVersion("0.23.0") and
-            check.func.__name__ in (
-                "check_classifiers_predictions",
-                "check_classifiers_classes",
-            )
+        if sklearn_version <= LooseVersion(
+            "0.23.0"
+        ) and check.func.__name__ in (
+            "check_classifiers_predictions",
+            "check_classifiers_classes",
         ):
             # These tests have issues that are fixed in 0.23.0
             pytest.skip()
@@ -640,12 +639,9 @@ class TestFullyCompliantWrappers:
 
     @parametrize_with_checks([FullyCompliantRegressor()])
     def test_fully_compliant_regressor(self, estimator, check):
-        if (
-            sklearn_version <= LooseVersion("0.23.0") and
-            check.func.__name__ in (
-                "check_methods_subset_invariance",
-            )
-        ):
+        if sklearn_version <= LooseVersion(
+            "0.23.0"
+        ) and check.func.__name__ in ("check_methods_subset_invariance",):
             # These tests have issues that are fixed in 0.23.0
             pytest.skip()
         check(estimator)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,11 +1,12 @@
 """Tests for Scikit-learn API wrapper."""
 
-
+from distutils.version import LooseVersion
 import pickle
 import os
 
 import numpy as np
 import pytest
+from sklearn import __version__ as sklearn_version
 from sklearn.base import clone
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.datasets import load_boston, load_digits, load_iris
@@ -625,10 +626,28 @@ class TestFullyCompliantWrappers:
 
     @parametrize_with_checks([FullyCompliantClassifier()])
     def test_fully_compliant_classifier(self, estimator, check):
+        if (
+            sklearn_version <= LooseVersion("0.23.0") and
+            check.func.__name__ in (
+                "check_classifiers_predictions",
+                "check_classifiers_classes",
+            )
+        ):
+            # These tests have issues that are fixed in 0.23.0
+            pytest.skip()
+
         check(estimator)
 
     @parametrize_with_checks([FullyCompliantRegressor()])
     def test_fully_compliant_regressor(self, estimator, check):
+        if (
+            sklearn_version <= LooseVersion("0.23.0") and
+            check.func.__name__ in (
+                "check_methods_subset_invariance",
+            )
+        ):
+            # These tests have issues that are fixed in 0.23.0
+            pytest.skip()
         check(estimator)
 
 


### PR DESCRIPTION
From testing in #39 I learned that future versions of Scikit-Learn are introducing a new test for the `sample_weight` parameter.

It seems that because of how Keras applies the `sample_weight` parameter, a value of `0` doesn't result in the sample being completely ignored.

This PR adds a manual step where any `sample_weight` values of exactly 0 result in those samples being deleted.