### PR TITLE
ENH: user friendly error if there is no loss function

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -339,8 +339,9 @@ class BaseWrapper(BaseEstimator):
             raise ValueError(
                 "No valid loss function found."
                 " You must provide a loss function to train."
-                "\n\nPlease provide a loss function via the `loss` parameter or"
-                " compile your model with a loss function within your `model`"
+                "\n\nTo resolve this issue, do one of the following:"
+                "\n 1. Provide a loss function via the loss parameter."
+                "\n 2. Compile your model with a loss function inside the"
                 " model-building method."
                 "\n\nSee https://www.tensorflow.org/api_docs/python/tf/keras/losses"
                 " for more information on Keras losses."

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -339,10 +339,10 @@ class BaseWrapper(BaseEstimator):
             raise ValueError(
                 "No valid loss function found."
                 " You must provide a loss function to train."
-                " Please provide a loss function via the `loss` parameter or"
+                "\nPlease provide a loss function via the `loss` parameter or"
                 " compile your model with a loss function within your `model`"
                 " model-building method."
-                " See https://www.tensorflow.org/api_docs/python/tf/keras/losses"
+                "\nSee https://www.tensorflow.org/api_docs/python/tf/keras/losses"
                 " for more information on Keras losses."
             )
 

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -339,10 +339,10 @@ class BaseWrapper(BaseEstimator):
             raise ValueError(
                 "No valid loss function found."
                 " You must provide a loss function to train."
-                "\nPlease provide a loss function via the `loss` parameter or"
+                "\n\nPlease provide a loss function via the `loss` parameter or"
                 " compile your model with a loss function within your `model`"
                 " model-building method."
-                "\nSee https://www.tensorflow.org/api_docs/python/tf/keras/losses"
+                "\n\nSee https://www.tensorflow.org/api_docs/python/tf/keras/losses"
                 " for more information on Keras losses."
             )
 

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -332,6 +332,16 @@ class BaseWrapper(BaseEstimator):
                 compile_kwargs = self._get_compile_kwargs()
             model.compile(**compile_kwargs)
 
+        if not getattr(model, "loss", None) or (
+            isinstance(model.loss, list) and all(l is None for l in model.loss)
+        ):
+            raise ValueError(
+                "You must provide a loss function to train a model."
+                " Please provide a loss function via the `loss` parameter or"
+                " compile your model with a loss function within your `model`"
+                " model-building method."
+            )
+
         return model
 
     def _fit_keras_model(self, X, y, sample_weight, warm_start):

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -333,13 +333,17 @@ class BaseWrapper(BaseEstimator):
             model.compile(**compile_kwargs)
 
         if not getattr(model, "loss", None) or (
-            isinstance(model.loss, list) and all(l is None for l in model.loss)
+            isinstance(model.loss, list)
+            and not any(callable(l) or isinstance(l, str) for l in model.loss)
         ):
             raise ValueError(
-                "You must provide a loss function to train a model."
+                "No valid loss function found."
+                " You must provide a loss function to train."
                 " Please provide a loss function via the `loss` parameter or"
                 " compile your model with a loss function within your `model`"
                 " model-building method."
+                " See https://www.tensorflow.org/api_docs/python/tf/keras/losses"
+                " for more information on Keras losses."
             )
 
         return model

--- a/tests/test_compile_kwargs.py
+++ b/tests/test_compile_kwargs.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from numpy.lib.arraysetops import isin
 from sklearn.datasets import make_classification
 from tensorflow.keras import losses as losses_module
 from tensorflow.keras import metrics as metrics_module

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -153,3 +153,29 @@ def test_no_loss(loss, compile):
     est = KerasRegressor(model=get_model, loss=loss, compile=compile)
     with pytest.raises(ValueError, match="must provide a loss function"):
         est.fit([[1]], [1])
+
+
+@pytest.mark.parametrize("compile", [True, False])
+def test_no_optimizer(compile):
+    def get_model(compile, meta, compile_kwargs):
+        inp = Input(shape=(meta["n_features_in_"],))
+        hidden = Dense(10, activation="relu")(inp)
+        out = [
+            Dense(1, activation="sigmoid", name=f"out{i+1}")(hidden)
+            for i in range(meta["n_outputs_"])
+        ]
+        model = Model(inp, out)
+        if compile:
+            model.compile(**compile_kwargs)
+        return model
+
+    est = KerasRegressor(
+        model=get_model,
+        loss="categorical_crossentropy",
+        compile=compile,
+        optimizer=None,
+    )
+    with pytest.raises(
+        ValueError, match="Could not interpret optimizer identifier"  # Keras error
+    ):
+        est.fit([[1]], [1])

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,8 +4,10 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
+from tensorflow.keras.layers import Dense, Input
+from tensorflow.keras.models import Model
 
-from scikeras.wrappers import BaseWrapper, KerasClassifier, KerasRegressor
+from scikeras.wrappers import KerasClassifier, KerasRegressor
 
 from .mlp_models import dynamic_classifier, dynamic_regressor
 
@@ -130,4 +132,24 @@ def test_build_fn_and_init_signature_do_not_agree(wrapper):
         est.fit([[1]], [1])
     est = wrapper(model=no_bar, bar=42, foo=43)
     with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+        est.fit([[1]], [1])
+
+
+@pytest.mark.parametrize("loss", [None, [None]])
+@pytest.mark.parametrize("compile", [True, False])
+def test_no_loss(loss, compile):
+    def get_model(compile, meta, compile_kwargs):
+        inp = Input(shape=(meta["n_features_in_"],))
+        hidden = Dense(10, activation="relu")(inp)
+        out = [
+            Dense(1, activation="sigmoid", name=f"out{i+1}")(hidden)
+            for i in range(meta["n_outputs_"])
+        ]
+        model = Model(inp, out)
+        if compile:
+            model.compile(**compile_kwargs)
+        return model
+
+    est = KerasRegressor(model=get_model, loss=loss, compile=compile)
+    with pytest.raises(ValueError, match="must provide a loss function"):
         est.fit([[1]], [1])


### PR DESCRIPTION
As discussed in several previous issues. Checks off a task on #79.

This does not break any APIs because it does not check the `__init__` param. Instead it directly checks `tf.keras.Model.loss` after the user returns control over to SciKeras.