### PR TITLE
MAINT/TST: stabilize new sklearn tests

### DIFF
--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -29,7 +29,7 @@ from .testing_utils import basic_checks, parametrize_with_checks
             # applicable to real world datasets
             batch_size=100,
             optimizer="adam",
-            model__hidden_layer_sizes=[]
+            model__hidden_layer_sizes=[],
             epochs=1,
         ),
         KerasRegressor(

--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -30,7 +30,7 @@ from .testing_utils import basic_checks, parametrize_with_checks
             batch_size=100,
             optimizer="adam",
             model__hidden_layer_sizes=[]
-            epochs=1
+            epochs=1,
         ),
         KerasRegressor(
             build_fn=dynamic_regressor,
@@ -44,7 +44,7 @@ from .testing_utils import basic_checks, parametrize_with_checks
             optimizer="adam",
             loss=KerasRegressor.r_squared,
             model__hidden_layer_sizes=[],
-            epochs=1
+            epochs=1,
         ),
     ],
     ids=["KerasClassifier", "KerasRegressor"],

--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -27,9 +27,11 @@ from .testing_utils import basic_checks, parametrize_with_checks
             # slightly if X is shuffled.
             # This is only required for this tests and is not really
             # applicable to real world datasets
-            batch_size=1000,
+            batch_size=100,
             optimizer="adam",
-            model__hidden_layer_sizes=(100,),
+            model__hidden_layer_sizes=[],
+            epochs=1,
+            random_state=0,
         ),
         KerasRegressor(
             build_fn=dynamic_regressor,
@@ -39,10 +41,12 @@ from .testing_utils import basic_checks, parametrize_with_checks
             # slightly if X is shuffled.
             # This is only required for this tests and is not really
             # applicable to real world datasets
-            batch_size=1000,
+            batch_size=100,
             optimizer="adam",
             loss=KerasRegressor.r_squared,
-            model__hidden_layer_sizes=(100,),
+            model__hidden_layer_sizes=[],
+            epochs=1,
+            random_state=0,
         ),
     ],
     ids=["KerasClassifier", "KerasRegressor"],

--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -31,7 +31,6 @@ from .testing_utils import basic_checks, parametrize_with_checks
             optimizer="adam",
             model__hidden_layer_sizes=[],
             epochs=1,
-            random_state=0,
         ),
         KerasRegressor(
             build_fn=dynamic_regressor,
@@ -46,7 +45,6 @@ from .testing_utils import basic_checks, parametrize_with_checks
             loss=KerasRegressor.r_squared,
             model__hidden_layer_sizes=[],
             epochs=1,
-            random_state=0,
         ),
     ],
     ids=["KerasClassifier", "KerasRegressor"],

--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -30,7 +30,6 @@ from .testing_utils import basic_checks, parametrize_with_checks
             batch_size=100,
             optimizer="adam",
             model__hidden_layer_sizes=[],
-            epochs=1,
         ),
         KerasRegressor(
             build_fn=dynamic_regressor,
@@ -44,7 +43,6 @@ from .testing_utils import basic_checks, parametrize_with_checks
             optimizer="adam",
             loss=KerasRegressor.r_squared,
             model__hidden_layer_sizes=[],
-            epochs=1,
         ),
     ],
     ids=["KerasClassifier", "KerasRegressor"],

--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -29,8 +29,8 @@ from .testing_utils import basic_checks, parametrize_with_checks
             # applicable to real world datasets
             batch_size=100,
             optimizer="adam",
-            model__hidden_layer_sizes=[],
-            epochs=1,
+            model__hidden_layer_sizes=[]
+            epochs=1
         ),
         KerasRegressor(
             build_fn=dynamic_regressor,
@@ -44,7 +44,7 @@ from .testing_utils import basic_checks, parametrize_with_checks
             optimizer="adam",
             loss=KerasRegressor.r_squared,
             model__hidden_layer_sizes=[],
-            epochs=1,
+            epochs=1
         ),
     ],
     ids=["KerasClassifier", "KerasRegressor"],


### PR DESCRIPTION
Fix failures in `check_methods_sample_order_invariance`. This seems to improve reliability, but possibly may not be 100% still.