### PR TITLE
MAINT: simplify loss_name and metric_name logic

### DIFF
--- a/scikeras/utils/__init__.py
+++ b/scikeras/utils/__init__.py
@@ -56,7 +56,8 @@ def loss_name(loss: Union[str, Loss, Callable]) -> str:
         loss = loss()
     if not (isinstance(loss, (str, Loss)) or callable(loss)):
         raise TypeError(
-            "`loss` must be a string, a function or an instance of tf.keras.losses.Loss"
+            "`loss` must be a string, a function, an instance of tf.keras.losses.Loss"
+            " or an instance of `tf.keras.losses.Loss`"
         )
     fn_or_cls = keras_loss_get(loss)
     if isinstance(fn_or_cls, Loss):
@@ -105,7 +106,7 @@ def metric_name(metric: Union[str, Metric, Callable]) -> str:
         raise TypeError(
             "`metric` must be a string, a function, an instance of"
             " tf.keras.metrics.Metric or a class inheriting from"
-            " tf.keras.metrics.Metric"
+            " `tf.keras.metrics.Metric`"
         )
     fn_or_cls = keras_metric_get(metric)
     if isinstance(fn_or_cls, Metric):

--- a/scikeras/utils/__init__.py
+++ b/scikeras/utils/__init__.py
@@ -15,6 +15,7 @@ def _camel2snake(s: str) -> str:
     """
     return "".join(["_" + c.lower() if c.isupper() else c for c in s]).lstrip("_")
 
+
 def loss_name(loss: Union[str, Loss, Callable]) -> str:
     """Retrieves a loss's full name (eg: "mean_squared_error").
 

--- a/scikeras/utils/__init__.py
+++ b/scikeras/utils/__init__.py
@@ -77,6 +77,10 @@ def metric_name(metric: Union[str, Metric, Callable]) -> str:
     str
         Full name for Keras metric. Ex: "mean_squared_error".
 
+    Notes
+    -----
+    The result of this function will always be in snake case, not camel case.
+
     Examples
     --------
     >>> metric_name("BinaryCrossentropy")
@@ -102,14 +106,7 @@ def metric_name(metric: Union[str, Metric, Callable]) -> str:
             " tf.keras.metrics.Metric or a class inheriting from"
             " tf.keras.metrics.Metric"
         )
-    try:
-        metric = serialize_metric(get_metric(metric))
-    except ValueError:
-        # Error messages change slightly across TF versions
-        # And errors are different for unknown strings vs. unknown objects
-        # We homogenize them to a single error message
-        raise ValueError(f"Unable to determine name for metric: {metric}")
-    if isinstance(metric, dict):
-        # classes are serialized as dicts
-        return metric["class_name"]
-    return metric  # for functions (serialize returns a string)
+    fn_or_cls = keras_metric_get(metric)
+    if isinstance(fn_or_cls, Metric):
+        return _camel2snake(fn_or_cls.__class__.__name__)
+    return fn_or_cls.__name__

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -439,7 +439,7 @@ class BaseWrapper(BaseEstimator):
         except (ValueError, TypeError):
             # unknown loss (ex: list of loss functions or custom loss)
             return
-        if given is not default_val and got is not given:
+        if given != default_val and got != given:
             raise ValueError(
                 f"loss={self.loss} but model compiled with {self.model_.loss}."
                 " Data may not match loss function!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,20 +15,16 @@ class CustomLoss(losses_module.Loss):
     "loss,expected,raises",
     [
         ("categorical_crossentropy", "categorical_crossentropy", None),
-        ("CategoricalCrossentropy", "CategoricalCrossentropy", None),
+        ("CategoricalCrossentropy", "categorical_crossentropy", None),
         (losses_module.categorical_crossentropy, "categorical_crossentropy", None),
-        (losses_module.CategoricalCrossentropy, "CategoricalCrossentropy", None),
-        (losses_module.CategoricalCrossentropy(), "CategoricalCrossentropy", None),
+        (losses_module.CategoricalCrossentropy, "categorical_crossentropy", None),
+        (losses_module.CategoricalCrossentropy(), "categorical_crossentropy", None),
         (object(), "", pytest.raises(TypeError, match="`loss` must be a")),
         (object, "", pytest.raises(TypeError, match="`loss` must be a")),
         (list(), "", pytest.raises(TypeError, match="`loss` must be a")),
-        (
-            "unknown_loss",
-            "",
-            pytest.raises(ValueError, match="Unable to determine name"),
-        ),
-        (CustomLoss, "CustomLoss", None),
-        (CustomLoss(), "CustomLoss", None),
+        ("unknown_loss", "", pytest.raises(ValueError, match="Unknown loss function"),),
+        (CustomLoss, "custom_loss", None),
+        (CustomLoss(), "custom_loss", None),
     ],
 )
 def test_loss_name(loss, expected, raises):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,59 +11,68 @@ class CustomLoss(losses_module.Loss):
     pass
 
 
-@pytest.mark.parametrize(
-    "loss,expected,raises",
-    [
-        ("categorical_crossentropy", "categorical_crossentropy", None),
-        ("CategoricalCrossentropy", "categorical_crossentropy", None),
-        (losses_module.categorical_crossentropy, "categorical_crossentropy", None),
-        (losses_module.CategoricalCrossentropy, "categorical_crossentropy", None),
-        (losses_module.CategoricalCrossentropy(), "categorical_crossentropy", None),
-        (object(), "", pytest.raises(TypeError, match="`loss` must be a")),
-        (object, "", pytest.raises(TypeError, match="`loss` must be a")),
-        (list(), "", pytest.raises(TypeError, match="`loss` must be a")),
-        ("unknown_loss", "", pytest.raises(ValueError, match="Unknown loss function"),),
-        (CustomLoss, "custom_loss", None),
-        (CustomLoss(), "custom_loss", None),
-    ],
-)
-def test_loss_name(loss, expected, raises):
-    if raises:
-        with raises:
-            got = loss_name(loss)
-    else:
-        got = loss_name(loss)
-        assert got == expected
-
-
 class CustomMetric(metrics_module.AUC):
     pass
 
 
 @pytest.mark.parametrize(
-    "metric,expected,raises",
+    "obj",
     [
-        ("categorical_crossentropy", "categorical_crossentropy", None),
-        ("CategoricalCrossentropy", "categorical_crossentropy", None),
-        (metrics_module.categorical_crossentropy, "categorical_crossentropy", None),
-        (metrics_module.CategoricalCrossentropy, "categorical_crossentropy", None),
-        (metrics_module.CategoricalCrossentropy(), "categorical_crossentropy", None),
-        (object(), "", pytest.raises(TypeError, match="`metric` must be a")),
-        (object, "", pytest.raises(TypeError, match="`metric` must be a")),
-        (list(), "", pytest.raises(TypeError, match="`metric` must be a")),
-        (
-            "unknown_metric",
-            "",
-            pytest.raises(ValueError, match="Unknown metric function"),
-        ),
-        (CustomMetric, "custom_metric", None),
-        (CustomMetric(), "custom_metric", None),
+        "categorical_crossentropy",
+        "CategoricalCrossentropy",
+        losses_module.categorical_crossentropy,
+        losses_module.CategoricalCrossentropy,
+        losses_module.CategoricalCrossentropy(),
     ],
 )
-def test_metric_name(metric, expected, raises):
-    if raises:
-        with raises:
-            got = metric_name(metric)
-    else:
-        got = metric_name(metric)
-        assert got == expected
+def test_loss_invariance(obj):
+    """Test to make sure loss_name returns same string no matter which object
+    is passed (str, function, class, type)"""
+    assert loss_name(obj) == "categorical_crossentropy"
+
+
+@pytest.mark.parametrize("obj", [CustomLoss, CustomLoss()])
+def test_custom_loss(obj):
+    assert loss_name(obj) == "custom_loss"
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        "categorical_crossentropy",
+        "CategoricalCrossentropy",
+        metrics_module.categorical_crossentropy,
+        metrics_module.CategoricalCrossentropy,
+        metrics_module.CategoricalCrossentropy(),
+    ],
+)
+def test_metric_invariance(obj):
+    """Test to make sure same metric returned no matter which object passed"""
+    assert metric_name(obj) == "categorical_crossentropy"
+
+
+@pytest.mark.parametrize("loss", [object(), object, list()])
+def test_loss_types(loss):
+    with pytest.raises(TypeError, match="`loss` must be a"):
+        loss_name(loss)
+
+
+def test_unknown_loss_raises():
+    with pytest.raises(ValueError, match="Unknown loss function"):
+        loss_name("unknown_loss")
+
+
+@pytest.mark.parametrize("obj", [object(), object, list()])
+def test_metric_types(obj):
+    with pytest.raises(TypeError, match="`metric` must be a"):
+        metric_name(obj)
+
+
+def test_unknown_metric():
+    with pytest.raises(ValueError, match="Unknown metric function"):
+        metric_name("unknown_metric")
+
+
+@pytest.mark.parametrize("metric", [CustomMetric, CustomMetric()])
+def test_custom_metric(metric):
+    assert metric_name(metric) == "custom_metric"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,20 +44,20 @@ class CustomMetric(metrics_module.AUC):
     "metric,expected,raises",
     [
         ("categorical_crossentropy", "categorical_crossentropy", None),
-        ("CategoricalCrossentropy", "CategoricalCrossentropy", None),
+        ("CategoricalCrossentropy", "categorical_crossentropy", None),
         (metrics_module.categorical_crossentropy, "categorical_crossentropy", None),
-        (metrics_module.CategoricalCrossentropy, "CategoricalCrossentropy", None),
-        (metrics_module.CategoricalCrossentropy(), "CategoricalCrossentropy", None),
+        (metrics_module.CategoricalCrossentropy, "categorical_crossentropy", None),
+        (metrics_module.CategoricalCrossentropy(), "categorical_crossentropy", None),
         (object(), "", pytest.raises(TypeError, match="`metric` must be a")),
         (object, "", pytest.raises(TypeError, match="`metric` must be a")),
         (list(), "", pytest.raises(TypeError, match="`metric` must be a")),
         (
             "unknown_metric",
             "",
-            pytest.raises(ValueError, match="Unable to determine name"),
+            pytest.raises(ValueError, match="Unknown metric function"),
         ),
-        (CustomMetric, "CustomMetric", None),
-        (CustomMetric(), "CustomMetric", None),
+        (CustomMetric, "custom_metric", None),
+        (CustomMetric(), "custom_metric", None),
     ],
 )
 def test_metric_name(metric, expected, raises):


### PR DESCRIPTION
**What does this PR implement?**
It simplifies the logic behind `loss_name` and `metric_name`. Now, the following are implemented:

* `loss_name` and `metric_name` always return a string in snake case. This means that `loss_name(tf.keras.losses.CategoricalCrossentropy) == loss_name("categorical_crossentropy")`.
* The tests are split up to test one thing at a time.

**Reference issues/PRs**
This comes from this thread: https://github.com/adriangb/scikeras/pull/88#discussion_r502819242.