### PR TITLE
MAINT: simplify logic in wrappers.py from #102

### DIFF
--- a/scikeras/utils/__init__.py
+++ b/scikeras/utils/__init__.py
@@ -57,7 +57,7 @@ def loss_name(loss: Union[str, Loss, Callable]) -> str:
     if not (isinstance(loss, (str, Loss)) or callable(loss)):
         raise TypeError(
             "`loss` must be a string, a function, an instance of tf.keras.losses.Loss"
-            " or an instance of `tf.keras.losses.Loss`"
+            " or a type inheriting from `tf.keras.losses.Loss`"
         )
     fn_or_cls = keras_loss_get(loss)
     if isinstance(fn_or_cls, Loss):
@@ -105,7 +105,7 @@ def metric_name(metric: Union[str, Metric, Callable]) -> str:
     if not (isinstance(metric, (str, Metric)) or callable(metric)):
         raise TypeError(
             "`metric` must be a string, a function, an instance of"
-            " tf.keras.metrics.Metric or a class inheriting from"
+            " tf.keras.metrics.Metric or a type inheriting from"
             " `tf.keras.metrics.Metric`"
         )
     fn_or_cls = keras_metric_get(metric)

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -431,19 +431,19 @@ class BaseWrapper(BaseEstimator):
         # check that if the user gave us a loss function it ended up in
         # the actual model
         default_val = inspect.signature(self.__init__).parameters["loss"].default
-        try:
+        if all(
+            isinstance(x, (str, losses_module.Loss, type))
+            for x in [self.loss, self.model_.loss]
+        ):  # filter out loss list/dicts/etc.
             if default_val is not None:
                 default_val = loss_name(default_val)
             given = loss_name(self.loss)
             got = loss_name(self.model_.loss)
-        except (ValueError, TypeError):
-            # unknown loss (ex: list of loss functions or custom loss)
-            return
-        if given != default_val and got != given:
-            raise ValueError(
-                f"loss={self.loss} but model compiled with {self.model_.loss}."
-                " Data may not match loss function!"
-            )
+            if given != default_val and got != given:
+                raise ValueError(
+                    f"loss={self.loss} but model compiled with {self.model_.loss}."
+                    " Data may not match loss function!"
+                )
 
     def _validate_data(
         self, X, y=None, reset: bool = False

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -413,7 +413,7 @@ class BaseWrapper(BaseEstimator):
         """
         # check if this is a multi-output model
         if self.model_n_outputs_ != len(self.model_.outputs):
-            raise RuntimeError(
+            raise ValueError(
                 "Detected an input of size"
                 f" {y[0].shape[0]}, but {self.model_} has"
                 f" {self.model_.outputs} outputs"

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -664,7 +664,8 @@ class BaseWrapper(BaseEstimator):
             if zeros.sum() == zeros.size:
                 raise ValueError(
                     "No training samples had any weight; only zeros were passed in sample_weight."
-                    " That means there's nothing to train on by definition, so training can not be completed."
+                    " That means there's nothing to train on by definition, so training can not be completed.\n\n"
+                    "To resolve this error, have at least one non-zero sample_weight"
                 )
             if np.any(zeros):
                 X = X[~zeros]

--- a/tests/test_input_outputs.py
+++ b/tests/test_input_outputs.py
@@ -318,7 +318,7 @@ def test_incompatible_output_dimensions():
 
     clf = KerasClassifier(model=build_fn_clf)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError, match="input of size"):
         clf.fit(X, y)
 
 


### PR DESCRIPTION
**What does this PR implement?**
It's a follow up on #102. It incorporates those changes into `wrappers.py`. Specifically, simplifies the logic in that file and removes the unnecessary try/except blocks.

It also renames an error from RuntimeError to ValueError, the proper error because an array of the wrong shape is passed, and adds some more information to other error messages.