### PR TITLE
MAINT: Remove _model_params property

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -185,15 +185,6 @@ class BaseWrapper(BaseEstimator):
     def __name__(self):
         return self.__class__.__name__
 
-    @property
-    def _model_params(self):
-        return {
-            k[len("model__") :]
-            for k in self.get_params()
-            if "model__" == k[: len("model__")]
-            or k in getattr(self, "_user_params", set())
-        }
-
     def _check_model_param(self):
         """Checks `model` and returns model building
         function to use.

--- a/tests/test_param_routing.py
+++ b/tests/test_param_routing.py
@@ -114,13 +114,6 @@ def test_no_extra_meta(wrapper_class, build_fn):
     assert set(clf.get_meta().keys()) == wrapper_class._meta - {"_user_params"}
 
 
-def test_model_params_property():
-    """Check that the `_model_params` property works as expected.
-    """
-    clf = KerasRegressor(model="test", model__hidden_layer_sizes=(100,))
-    assert clf._model_params == {"hidden_layer_sizes"}
-
-
 @pytest.mark.parametrize("dest", ["fit", "compile", "predict"])
 def test_routing_sets(dest):
     accepted_params = set(inspect.signature(getattr(Model, dest)).parameters.keys()) - {


### PR DESCRIPTION
Closes #107.

`_model_params` was added in #67, but is never used in SciKeras. It could have been used within `BaseWrapper._build_keras_model`, but that same PR implements `route_params` which is used instead and is much more flexible. In fact, the code implemented in `_build_keras_model`: https://github.com/adriangb/scikeras/blob/9f633f5c21a45b43986a8d779c3ef9e3005038bb/scikeras/wrappers.py#L300-L305

Ends up being the same thing as `_model_params`:
https://github.com/adriangb/scikeras/blob/9f633f5c21a45b43986a8d779c3ef9e3005038bb/scikeras/wrappers.py#L188-L195

I think that we should delete this method/property, and that is what is being proposed in this PR.