### PR TITLE
ENH: allow explicit initialization of estimators without fitting for …

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -643,6 +643,20 @@ class BaseWrapper(BaseEstimator):
         return X, y
 
     def initialize(self, X: np.ndarray, y: Union[np.ndarray, None] = None) -> None:
+        """Initialize the model without any fitting.
+
+        You only need to call this model if you explicitly do not want to do any fitting
+        (for example with a pretrained model). You should _not_ call this
+        right before calling ``fit``, calling ``fit`` will do this automatically.
+
+        Parameters
+        ----------
+        X : array-like, shape `(n_samples, n_features)`
+                Training samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+        y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`, optional
+            True labels for `X`, by default None.
+        """
         self._initialize(X, y)
 
     def _fit(self, X, y, sample_weight, warm_start, epochs, initial_epoch):

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -642,7 +642,9 @@ class BaseWrapper(BaseEstimator):
 
         return X, y
 
-    def initialize(self, X: np.ndarray, y: Union[np.ndarray, None] = None) -> None:
+    def initialize(
+        self, X: np.ndarray, y: Union[np.ndarray, None] = None
+    ) -> "BaseModel":
         """Initialize the model without any fitting.
 
         You only need to call this model if you explicitly do not want to do any fitting
@@ -656,8 +658,14 @@ class BaseWrapper(BaseEstimator):
                 and `n_features` is the number of features.
         y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`, optional
             True labels for `X`, by default None.
+        
+        Returns
+        -------
+        BaseModel
+            A reference to the BaseModel instance for chained calling.
         """
         self._initialize(X, y)
+        return self  # to allow chained calls like initialize(...).predict(...)
 
     def _fit(self, X, y, sample_weight, warm_start, epochs, initial_epoch):
         """Constructs a new model with `build_fn` & fit the model to `(X, y)`.


### PR DESCRIPTION
As discussed in https://github.com/adriangb/scikeras/pull/123#discussion_r518909777

Shuffles around existing logic into a new public `BaseWrapper.initialize` method that allows explicit initialization of SciKeras estimators without needing to call fit / doing any fitting of the actual Keras Model. This same method is called automatically when `fit` is called.