### PR TITLE
TST: allow tests to continue if dev tests fail

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,6 @@ jobs:
       - uses: codecov/codecov-action@v1
 
   TestDev:
-    continue-on-error: 
     needs: Linting
     name: Ubuntu / Python ${{ matrix.python-version }} / TensorFlow Nightly / Scikit-Learn Nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,7 @@ jobs:
       - uses: codecov/codecov-action@v1
 
   TestDev:
+    continue-on-error: 
     needs: Linting
     name: Ubuntu / Python ${{ matrix.python-version }} / TensorFlow Nightly / Scikit-Learn Nightly
     runs-on: ubuntu-latest
@@ -83,11 +84,13 @@ jobs:
           poetry install
 
       - name: Install Nightly Versions
+        if: always()
         run: |
           poetry run python -m pip install -U tf-nightly
           poetry run python -m pip install -U --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
 
-      - name: Test with pytest 
+      - name: Test with pytest
+        if: always()
         run: |
           poetry run python -m pip freeze
           poetry run python -m pytest -v --cov=scikeras --cov-report xml --numprocesses=auto --color=yes


### PR DESCRIPTION
The latests sklearn nightly seems to specify scipy>=19... The latest version of scipy is 15. This PR allows other tests to keep running when nightly tests fail, but still marks the nightly as failed.