### PR TITLE
BUG: ensure epochs can be passes as a **kwarg to fit

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -742,14 +742,14 @@ class BaseWrapper(BaseEstimator):
                 f" Instead, set fit arguments at initialization (i.e., ``BaseWrapper({k}={v})``)"
             )
 
+        # epochs via kwargs > fit__epochs > epochs
+        kwargs["epochs"] = kwargs.get(
+            "epochs", getattr(self, "fit__epochs", self.epochs)
+        )
+        kwargs["initial_epoch"] = kwargs.get("initial_epoch", 0)
+
         self._fit(
-            X=X,
-            y=y,
-            sample_weight=sample_weight,
-            warm_start=self.warm_start,
-            epochs=getattr(self, "fit__epochs", self.epochs),
-            initial_epoch=0,
-            **kwargs,
+            X=X, y=y, sample_weight=sample_weight, warm_start=self.warm_start, **kwargs,
         )
 
         return self


### PR DESCRIPTION
Because `epoch` was a hardcoded parameter to `_fit` when called from `fit`, it could not be passes within `fit`'s `**kwargs`. As long as we are allowing `**kwargs`, there is no reason for `epochs` alone to fail.