### PR TITLE
BUG: docs can't be built from forks

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout docs branch
         uses: actions/checkout@v2
         with:
-          ref: refs/heads/docs
+          ref: refs/heads/docs-deploy
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,49 @@
+
+name: Deploy Docs
+
+on:
+  workflow_run:
+    workflows:
+      - Build Docs
+    types:
+      - completed
+
+jobs:
+  deploy:
+    name: Deploy Docs
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Checkout docs branch
+        uses: actions/checkout@v2
+        with:
+          ref: refs/heads/docs
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.name }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: docs
+
+      - name: Update versions
+        run: python update_versions.py
+
+      - name: Deploy docs
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add -A
+          if ! git diff-index --quiet HEAD --; then
+            echo "Deploying changes"
+            git status
+            git commit -m "Deploy docs from ${{ github.event.workflow_run.head_branch }}"
+            git push -f
+          else
+            echo "No changes to deploy"
+            exit 0
+          fi

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: Docs
+name: Build Docs
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,8 +4,8 @@ on:
     branches: [ master ]
   pull_request:
   release:
-  types:
-    - published
+    types:
+      - published
 
 jobs:
   notebooks:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ master ]
   pull_request:
+  release:
+  types:
+    - published
 
 jobs:
   notebooks:
@@ -37,19 +40,14 @@ jobs:
 
       - name: Build the docs
         run: |
-          poetry run sphinx-build -b html -j 2 docs/source docs/_build
+          poetry run sphinx-build -b html -j 2 docs/source docs/_build/${{ github.ref }}
 
-      - name: Deploy docs
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+      - name: Save docs artifact
+        uses: actions/upload-artifact@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: docs-deploy
-          FOLDER: docs/_build
-          CLEAN: true
-          TARGET_FOLDER: ${{ github.ref }}
-          SINGLE_COMMIT: true
-          PRESERVE: true
-      
+          name: docs
+          path: docs/_build/*
+
       - name: Print docs link
         run: |
           echo "Docs available at https://www.adriangb.com/scikeras/${{ github.ref }}/"


### PR DESCRIPTION
As evidenced by #176 , docs can't be deployed from a fork, for security reasons.

The workaround is to have 2 workflows: one to build, one to deploy.

The build workflow is run from the fork (i.e. the PR author can edit this workflow to their hearts content) and the only expectation is that a folder with HTML stuff is published.

The deploy workflow is run from master. The security concern is alleviated because PR authors can't use workflows to push code without review. This workflow will never be runnable from the PR that is updating it, but luckily it shouldn't need to be updated very often.