### PR TITLE
MAINT: add importlib-metadata dep for python <3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ repository = "https://github.com/adriangb/scikeras"
 version = "0.2.1"
 
 [tool.poetry.dependencies]
+importlib-metadata = {version = "^3.4.0", python = "<3.8"}
 python = ">=3.6.7, <3.9"
 scikit-learn = "^0.22.0"
 tensorflow = "^2.4.0"

--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -2,10 +2,12 @@
 
 __author__ = """Adrian Garcia Badaracco"""
 
-from importlib import metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata  # python <3.8
 
-
-__version__ = metadata.version("scikeras")
+__version__ = importlib_metadata.version("scikeras")
 
 from tensorflow import keras as _keras
 


### PR DESCRIPTION
Missing from #190 