### PR TITLE
ENH: Add default loss to KerasClassifier

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -1327,12 +1327,12 @@ class KerasClassifier(BaseWrapper):
             ):
                 raise ValueError(
                     "The model is configured to have one output, but the "
-                    f"loss='{self.loss}' can not handle multiple outputs. "
-                    "This loss is often used with one-hot encoded targets."
+                    f"loss='{self.loss}' is expecting multiple outputs "
+                    "(which is often used with one-hot encoded targets). "
                     "More detail on Keras losses: https://keras.io/api/losses/"
                 ) from e
             else:
-                raise ValueError("{self.loss}, {self.model_.outputs}")
+                raise e
 
 
     @staticmethod

--- a/tests/test_simple_usage.py
+++ b/tests/test_simple_usage.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+from sklearn.datasets import make_classification
+
+from scikeras.wrappers import KerasClassifier
+
+N_CLASSES = 4
+FEATURES = 8
+n_eg = 100
+X = np.random.uniform(size=(n_eg, FEATURES))
+y = np.random.choice(N_CLASSES, size=n_eg)
+
+
+def clf(single_output=False):
+    model = tf.keras.Sequential()
+    model.add(tf.keras.layers.Input(shape=(FEATURES,)))
+    model.add(tf.keras.layers.Dense(FEATURES))
+
+    if single_output:
+        model.add(tf.keras.layers.Dense(1))
+    else:
+        model.add(tf.keras.layers.Dense(N_CLASSES))
+
+    return model
+
+
+def test_classifier_loss_defaults():
+    est = KerasClassifier(model=clf)
+    est.partial_fit(X, y=y)
+    assert est.current_epoch == 1
+
+
+def test_classifier_raises_for_single_output():
+    est = KerasClassifier(model=clf, model__single_output=True)
+    msg = (
+        "one output, but the loss='categorical_crossentropy' "
+        "can not handle multiple outputs"
+    )
+    with pytest.raises(ValueError, match=msg):
+        est.partial_fit(X, y)
+    assert est.current_epoch == 0

--- a/tests/test_simple_usage.py
+++ b/tests/test_simple_usage.py
@@ -8,8 +8,8 @@ from scikeras.wrappers import KerasClassifier
 N_CLASSES = 4
 FEATURES = 8
 n_eg = 100
-X = np.random.uniform(size=(n_eg, FEATURES))
-y = np.random.choice(N_CLASSES, size=n_eg)
+X = np.random.uniform(size=(n_eg, FEATURES)).astype("float32")
+y = np.random.choice(N_CLASSES, size=n_eg).astype(int)
 
 
 def clf(single_output=False):
@@ -25,17 +25,40 @@ def clf(single_output=False):
     return model
 
 
-def test_classifier_loss_defaults():
+def test_classifier_only_model_specified():
+    """
+    This tests uses cases where KerasClassifier works with the default loss.
+    It works for the following cases:
+
+    * binary classification
+    * one hot classification
+    * single class classification
+
+    """
     est = KerasClassifier(model=clf)
     est.partial_fit(X, y=y)
     assert est.current_epoch == 1
 
+    for y2 in [
+        np.random.choice(2, size=len(X)).astype(int),
+        (np.random.choice(2, size=len(X)).astype(int) * 2 - 1),
+        np.ones(len(X)).astype(int),
+        np.zeros(len(X)).astype(int),
+    ]:
+        est = KerasClassifier(model=clf, model__single_output=True)
+        est.partial_fit(X, y=y2)
+        assert est.current_epoch == 1
 
-def test_classifier_raises_for_single_output():
+
+def test_classifier_raises_for_single_output_with_multiple_classes():
+    """
+    KerasClassifier does not work with one output and multiple classes
+    in the target (duh).
+    """
     est = KerasClassifier(model=clf, model__single_output=True)
     msg = (
-        "one output, but the loss='categorical_crossentropy' "
-        "can not handle multiple outputs"
+        "The model is configured to have one output, but the "
+        "loss='categorical_crossentropy' is expecting multiple outputs "
     )
     with pytest.raises(ValueError, match=msg):
         est.partial_fit(X, y)


### PR DESCRIPTION
**What does this PR implement?**
It adds `loss="categorical_crossentropy"` to KerasClassifier by default. It adds some protection in case the user passes multiple classes in `y` but the model is only configured for one class.

**Reference issues/PR**
This PR closes https://github.com/adriangb/scikeras/issues/206