### PR TITLE
attempt at default losses

### DIFF
--- a/scikeras/utils/transformers.py
+++ b/scikeras/utils/transformers.py
@@ -154,7 +154,7 @@ class ClassifierLabelEncoder(BaseEstimator, TransformerMixin):
             "multiclass-multioutput": FunctionTransformer(),
             "multilabel-indicator": FunctionTransformer(),
         }
-        if is_categorical_crossentropy(self.loss):
+        if target_type == "multiclass" and is_categorical_crossentropy(self.loss):
             encoders["multiclass"] = make_pipeline(
                 TargetReshaper(),
                 OneHotEncoder(

--- a/tests/mlp_models.py
+++ b/tests/mlp_models.py
@@ -26,11 +26,16 @@ def dynamic_classifier(
     for layer_size in hidden_layer_sizes:
         hidden = Dense(layer_size, activation="relu")(hidden)
 
+    if compile_kwargs["loss"] == "auto":
+        loss = None
+    else:
+        loss = compile_kwargs["loss"]
+
     if target_type_ == "binary":
-        compile_kwargs["loss"] = compile_kwargs["loss"] or "binary_crossentropy"
+        compile_kwargs["loss"] = loss or "binary_crossentropy"
         out = [Dense(1, activation="sigmoid")(hidden)]
     elif target_type_ == "multilabel-indicator":
-        compile_kwargs["loss"] = compile_kwargs["loss"] or "binary_crossentropy"
+        compile_kwargs["loss"] = loss or "binary_crossentropy"
         if isinstance(n_classes_, list):
             out = [
                 Dense(1, activation="sigmoid")(hidden)
@@ -39,13 +44,11 @@ def dynamic_classifier(
         else:
             out = Dense(n_classes_, activation="softmax")(hidden)
     elif target_type_ == "multiclass-multioutput":
-        compile_kwargs["loss"] = compile_kwargs["loss"] or "binary_crossentropy"
+        compile_kwargs["loss"] = loss or "binary_crossentropy"
         out = [Dense(n, activation="softmax")(hidden) for n in n_classes_]
     else:
         # multiclass
-        compile_kwargs["loss"] = (
-            compile_kwargs["loss"] or "sparse_categorical_crossentropy"
-        )
+        compile_kwargs["loss"] = loss or "sparse_categorical_crossentropy"
         out = [Dense(n_classes_, activation="softmax")(hidden)]
 
     model = Model(inp, out)
@@ -60,13 +63,13 @@ def dynamic_regressor(
     meta: Optional[Dict[str, Any]] = None,
     compile_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Model:
-    """Creates a basic MLP regressor dynamically.
-    """
+    """Creates a basic MLP regressor dynamically."""
     # get parameters
     n_features_in_ = meta["n_features_in_"]
     n_outputs_ = meta["n_outputs_"]
 
-    compile_kwargs["loss"] = compile_kwargs["loss"] or "mse"
+    if compile_kwargs["loss"] == "auto":
+        compile_kwargs["loss"] = "mean_squared_error"
 
     inp = Input(shape=(n_features_in_,))
 


### PR DESCRIPTION
@stsievert  a parallel proposal to #208 

This implements a default loss `"auto"` for KerasClassifier and KerasRegressor. An appropriate loss function is only selected if:
1. The user did not provide a loss function (i.e. the default "auto" was passed).
2. The user did not compile the model.

For KerasRegressor, it always defaults to "mse" and supports any number of outputs.

For KerasClassifier, it defaults to "binary_crossentropy" for binary targets, "sparse_categorical_crossentropy" for "multiclass" targets and and "categorical_crossentropy" for all other problems. Only single outputs are supported. An error is raised if there is >1 output or if a different task type not listed above is passed (eg: multilabel-indicator).