### PR TITLE
MAINT: better .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,25 @@
-docs/source/generated
+# Exclude all
+/*
+/*/
+
+# Include project files
+!/.github
+!/docs
+!/scikeras
+!/tests
+!/pyproject.toml
+!/.gitignore
+!/.pre-commit-config.yaml
+!/codecov.yaml
+!/*.md
+!/*.rst
+!/LICENSE
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
 
 # Distribution / packaging
 .Python
@@ -27,87 +40,10 @@ wheels/
 .installed.cfg
 *.egg
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# dotenv
-.env
-
-# virtualenv
-.venv
-venv/
-ENV/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-
-# IDE settings
-.vscode/
 
 # MacOS files
 .DS_Store
 
 # Executed notebooks
+docs/source/generated
 docs/source/notebooks/*.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -21,29 +21,11 @@ __pycache__/
 *$py.class
 
 
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-
-
 # MacOS files
 .DS_Store
 
 # Executed notebooks
-docs/source/generated
-docs/source/notebooks/*.ipynb
+/docs/source/generated
+/docs/source/notebooks/*.ipynb
+**/.ipynb_checkpoints
+/docs/_build


### PR DESCRIPTION
This reduces the number of named things that we don't use by excluding everything except the project files.

This also avoids accidentally committing test files and such at the repo root.