### PR TITLE
ENH: support unbuilt Model serialization

### DIFF
--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -14,6 +14,8 @@ from tensorflow import keras as _keras
 from scikeras import _saving_utils
 
 
+_keras.Model.__copy__ = _saving_utils.copy_keras_model
+_keras.Model.__deepcopy__ = _saving_utils.deepcopy_keras_model
 _keras.Model.__reduce__ = _saving_utils.pack_keras_model
 _keras.losses.Loss.__reduce__ = _saving_utils.pack_keras_loss
 _keras.metrics.Metric.__reduce__ = _saving_utils.pack_keras_metric

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -263,21 +263,15 @@ def test_model_connect_build_compile_fit():
     X, y = make_regression(n_features=10, n_samples=100)
     # Start with an unbuilt model with no inputs/outputs
     # this shold be copyable, but not necessarily serializable
-    # (SaveModel needs a conencted graph)
     model = keras.Model()
     model = copy.deepcopy(model)
     model = copy.copy(model)
+    # Adding inputs and outputs
+    # the model should be copyable and serializable
     inp = keras.layers.Input(X.shape[1])
     output = keras.layers.Dense(1)(inp)
-    # Adding inputs and outputs
-    # the model should still be copyable, but not necessarily serializable
     model = keras.Model(inp, output)
-    model = copy.deepcopy(model)
-    model = copy.copy(model)
-    # Now we build the model
-    # at this point, it should be copyable and serializable
-    model.build(X.shape)
-    model = pickle.loads(pickle.dumps(model))
+    pickle.loads(pickle.dumps(model))
     model = copy.deepcopy(model)
     model = copy.copy(model)
     # Next compile the model and check that compiling after building


### PR DESCRIPTION
Bringing over learnings from https://github.com/tensorflow/tensorflow/pull/39609

`SaveModel` does not support currently support unbuilt models, but at the same time these can be _copied_ using default Python implementations. So the way this is set up:

|         | pickle                                      | copy                              |
|---------|---------------------------------------------|-----------------------------------|
| built   | via SaveModel                               | via SaveModel                     |
| unbuilt | via SaveModel, let Keras handle the failure | via `object.__reduce__` |