### PR TITLE
Fix dependency specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,29 +27,29 @@ license = "MIT"
 name = "scikeras"
 readme = "README.md"
 repository = "https://github.com/adriangb/scikeras"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
-importlib-metadata = {version = "^3.4.0", python = "<3.8"}
-python = ">=3.6.7,<4"
-scikit-learn = "^0.22.0"
-tensorflow = "^2.4.0"
+importlib-metadata = {version = "^3", python = "<3.8"}
+python = ">=3.6.1,<4.0"
+scikit-learn = "^0"
+tensorflow = "^2"
 
 [tool.poetry.dev-dependencies]
-coverage = {extras = ["toml"], version = "^5.4"}
+coverage = {extras = ["toml"], version = ">=5.4"}
 dataclasses = {version = "^0.8", python = "<3.7"}
-insipid-sphinx-theme = "^0.2.2"
-ipykernel = "^5.4.2"
-jupyter = "^1.0.0"
-jupytext = "^1.9.1"
-matplotlib = "^3.3.3"
-nbsphinx = "^0.8.1"
-numpydoc = "^1.1.0"
-pre-commit = "^2.10.1"
-pytest = "^6.2.2"
-pytest-cov = "^2.11.1"
-pytest-sugar = "^0.9.4"
-pytest-xdist = "^2.2.1"
+insipid-sphinx-theme = ">=0.2.2"
+ipykernel = ">=5.4.2"
+jupyter = ">=1.0.0"
+jupytext = ">=1.9.1"
+matplotlib = ">=3.3.3"
+nbsphinx = ">=0.8.1"
+numpydoc = ">=1.1.0"
+pre-commit = ">=2.10.1"
+pytest = ">=6.2.2"
+pytest-cov = ">=2.11.1"
+pytest-sugar = "v0.9.4"
+pytest-xdist = ">=2.2.1"
 sphinx = ">=3.2.1"
 
 [tool.isort]


### PR DESCRIPTION
This fixes incorrect dependency specification which was causing sklearn to be stuck at `0.22.0`.