### PR TITLE
MAINT: Fix keras imports on tf-nightly after the keras/tf repo split

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Test with pytest 
         run: |
           poetry run python -m pip freeze
-          poetry run python -m pytest -v --cov=scikeras --cov-report xml--color=yes
+          poetry run python -m pytest -v --cov=scikeras --cov-report xml --color=yes
 
       - uses: codecov/codecov-action@v1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Test with pytest 
         run: |
           poetry run python -m pip freeze
-          poetry run python -m pytest -v --cov=scikeras --cov-report xml --numprocesses=auto --color=yes
+          poetry run python -m pytest -v --cov=scikeras --cov-report xml--color=yes
 
       - uses: codecov/codecov-action@v1
 
@@ -90,7 +90,7 @@ jobs:
         if: always()
         run: |
           poetry run python -m pip freeze
-          poetry run python -m pytest -v --cov=scikeras --cov-report xml --numprocesses=auto --color=yes
+          poetry run python -m pytest -v --cov=scikeras --cov-report xml --color=yes
 
       - uses: codecov/codecov-action@v1
 
@@ -126,7 +126,7 @@ jobs:
       - name: Test with pytest 
         run: |
           poetry run python -m pip freeze
-          poetry run python -m pytest -v --cov=scikeras --cov-report xml --numprocesses=auto --color=yes
+          poetry run python -m pytest -v --cov=scikeras --cov-report xml --color=yes
 
       - uses: codecov/codecov-action@v1
 
@@ -160,6 +160,6 @@ jobs:
       - name: Test with pytest
         run: |
           poetry run python -m pip freeze
-          poetry run python -m pytest -v --cov=scikeras --cov-report xml --numprocesses=auto --color=yes
+          poetry run python -m pytest -v --cov=scikeras --cov-report xml --color=yes
 
       - uses: codecov/codecov-action@v1

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -45,7 +45,7 @@ We use Poetry_ to manage dependencies.
     poetry install
     poetry shell
 
-    pytest -n auto  # parallelized tests via pytest-xdist
+    pytest -v
 
 
 .. _Poetry: https://python-poetry.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ pre-commit = ">=2.10.1"
 pytest = ">=6.2.2"
 pytest-cov = ">=2.11.1"
 pytest-sugar = "v0.9.4"
-pytest-xdist = ">=2.2.1"
 sphinx = ">=3.2.1"
 
 [tool.isort]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,16 +18,15 @@ from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
+from tensorflow import keras
+from tensorflow.keras import backend as K
 from tensorflow.keras import losses as losses_module
 from tensorflow.keras import metrics as metrics_module
 from tensorflow.keras.layers import Conv2D, Dense, Flatten, Input
 from tensorflow.keras.models import Model, Sequential
-from tensorflow.python import keras
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.utils.generic_utils import register_keras_serializable
-from tensorflow.python.keras.utils.np_utils import to_categorical
+from tensorflow.keras.utils import register_keras_serializable, to_categorical
 
-from scikeras.wrappers import BaseWrapper, KerasClassifier, KerasRegressor
+from scikeras.wrappers import KerasClassifier, KerasRegressor
 
 from .mlp_models import dynamic_classifier, dynamic_regressor
 from .testing_utils import basic_checks

--- a/tests/test_input_outputs.py
+++ b/tests/test_input_outputs.py
@@ -8,7 +8,6 @@ import pytest
 import tensorflow as tf
 
 from sklearn.base import BaseEstimator
-from sklearn.datasets import make_classification, make_regression
 from sklearn.metrics import accuracy_score, r2_score
 from sklearn.model_selection import train_test_split
 from sklearn.multioutput import (
@@ -16,8 +15,8 @@ from sklearn.multioutput import (
 )
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 from sklearn.preprocessing import FunctionTransformer, OneHotEncoder
-from tensorflow.python.keras.layers import Concatenate, Dense, Input
-from tensorflow.python.keras.models import Model
+from tensorflow.keras.layers import Concatenate, Dense, Input
+from tensorflow.keras.models import Model
 
 from scikeras.wrappers import BaseWrapper, KerasClassifier, KerasRegressor
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from sklearn.metrics import r2_score as sklearn_r2_score
-from tensorflow.python.framework.ops import convert_to_tensor
+from tensorflow import convert_to_tensor
 
 from scikeras.wrappers import KerasRegressor
 


### PR DESCRIPTION
- Replace `tf.python.keras` imports with `tf.keras` imports
- Clean up string -> class conversion for optimizers, losses and metrics
- Remove pytest-xdist since it seems that random state configuration is no longer compatible with multiprocess execution of tests (evidenced by fragility in training results)