### PR TITLE
Fix handling of class_weight=balanced

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -1357,7 +1357,7 @@ class KerasClassifier(BaseWrapper):
     @property
     def _fit_kwargs(self) -> Set[str]:
         # remove class_weight since KerasClassifier re-processes it into sample_weight
-        return BaseWrapper._fit_kwargs - set(("class_weight",))
+        return BaseWrapper._fit_kwargs - {"class_weight"}
 
     @staticmethod
     def scorer(y_true, y_pred, **kwargs) -> float:

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -4,7 +4,7 @@ import inspect
 import warnings
 
 from collections import defaultdict
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Set, Tuple, Type, Union
 
 import numpy as np
 import tensorflow as tf
@@ -1353,6 +1353,11 @@ class KerasClassifier(BaseWrapper):
             # check that this is not a multiclass problem missing categories
             target_type = type_of_target(self.classes_)
         return target_type
+
+    @property
+    def _fit_kwargs(self) -> Set[str]:
+        # remove class_weight since KerasClassifier re-processes it into sample_weight
+        return BaseWrapper._fit_kwargs - set(("class_weight",))
 
     @staticmethod
     def scorer(y_true, y_pred, **kwargs) -> float:


### PR DESCRIPTION
Fixes use of `class_weight` parameter.

Currently, the `class_weight` parameter passed to the `KerasClassifier` constructor gets passed to Keras, which breaks `class_weight="balanced"` and any other values that are supported by Scikit-Learn (which we want to support in SciKeras) but no in Keras.