### PR TITLE
BREAKING CHANGE: bump TensorFlow dependency to 2.7.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         os: [MacOS, Windows]  # test all OSs (except Ubuntu, which is already running other tests)
-        python-version: [3.6.7, 3.8.5]  # test only the two extremes of supported Python versions
+        python-version: [3.7, 3.9]  # test only the two extremes of supported Python versions
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,8 +100,8 @@ jobs:
     strategy:
       matrix:
         tf-version: [2.7.0]
-        python-version: [3.6, 3.8]
-        sklearn-version: [0.23.0]
+        python-version: [3.7, 3.8]
+        sklearn-version: [1.0.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         tf-version: [2.7.0]
         python-version: [3.6, 3.8]
-        sklearn-version: [0.22.0]
+        sklearn-version: [0.23.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [2.4.0]
+        tf-version: [2.7.0]
         python-version: [3.6, 3.8]
         sklearn-version: [0.22.0]
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package is available on PyPi:
 pip install scikeras
 ```
 
-The only dependencies are `scikit-learn>=0.22` and `TensorFlow>=2.4.0`.
+The only dependencies are `scikit-learn>=0.22` and `TensorFlow>=2.7.0`.
 
 You will need to manually install TensorFlow; due to TensorFlow's packaging it is not a direct dependency of SciKeras.
 You can do this by running:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package is available on PyPi:
 pip install scikeras
 ```
 
-SciKeras depends on `scikit-learn>=0.23.0` and `TensorFlow>=2.7.0`.
+SciKeras depends on `scikit-learn>=1.0.0` and `TensorFlow>=2.7.0`.
 
 You will need to manually install TensorFlow; due to TensorFlow's packaging it is not a direct dependency of SciKeras.
 You can do this by running:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package is available on PyPi:
 pip install scikeras
 ```
 
-SciKeras depends on `scikit-learn>=1.0.0` and `TensorFlow>=2.7.0`.
+The current version of SciKeras depends on `scikit-learn>=1.0.0` and `TensorFlow>=2.7.0`.
 
 You will need to manually install TensorFlow; due to TensorFlow's packaging it is not a direct dependency of SciKeras.
 You can do this by running:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package is available on PyPi:
 pip install scikeras
 ```
 
-The only dependencies are `scikit-learn>=0.22` and `TensorFlow>=2.7.0`.
+SciKeras depends on `scikit-learn>=0.23.0` and `TensorFlow>=2.7.0`.
 
 You will need to manually install TensorFlow; due to TensorFlow's packaging it is not a direct dependency of SciKeras.
 You can do this by running:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -32,7 +32,7 @@ You can also install SciKeras without any dependencies, for example to install a
 
     pip install --no-deps scikeras
 
-As of SciKeras v0.4.0, the minimum required versions are as follows:
+As of SciKeras v0.5.0, the minimum required versions are as follows:
 
 - TensorFlow: v2.7.0
 - Scikit-Learn: v1.0.0

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,7 +35,7 @@ You can also install SciKeras without any dependencies, for example to install a
 As of SciKeras v0.4.0, the minimum required versions are as follows:
 
 - TensorFlow: v2.7.0
-- Scikit-Learn: v0.22.0
+- Scikit-Learn: v0.23.0
 
 Developer Installation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -34,7 +34,7 @@ You can also install SciKeras without any dependencies, for example to install a
 
 As of SciKeras v0.4.0, the minimum required versions are as follows:
 
-- TensorFlow: v2.4.0
+- TensorFlow: v2.7.0
 - Scikit-Learn: v0.22.0
 
 Developer Installation

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,7 +35,7 @@ You can also install SciKeras without any dependencies, for example to install a
 As of SciKeras v0.4.0, the minimum required versions are as follows:
 
 - TensorFlow: v2.7.0
-- Scikit-Learn: v0.23.0
+- Scikit-Learn: v1.0.0
 
 Developer Installation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/notebooks/Benchmarks.md
+++ b/docs/source/notebooks/Benchmarks.md
@@ -106,13 +106,13 @@ fit_kwargs = {"batch_size": 128, "validation_split": 0.1, "verbose": 0, "epochs"
 
 ```python
 from sklearn.metrics import accuracy_score
-from scikeras._utils import TFRandomState
+from scikeras._utils import tensorflow_random_state
 ```
 
 ```python
 from time import time
 
-with TFRandomState(seed=0):  # we force a TF random state to be able to compare accuracy
+with tensorflow_random_state(seed=0):  # we force a TF random state to be able to compare accuracy
     model = get_model()
     start = time()
     model.fit(x_train, y_train, **fit_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.4.1"
 
 [tool.poetry.dependencies]
 importlib-metadata = {version = "^3", python = "<3.8"}
-python = ">=3.6.1,<4.0"
+python = ">=3.6.1,<3.10.0"
 scikit-learn = ">=1.0.0"
 packaging = ">=0.21,<22.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ version = "0.4.1"
 [tool.poetry.dependencies]
 importlib-metadata = {version = "^3", python = "<3.8"}
 python = ">=3.6.1,<4.0"
-scikit-learn = ">=0.22.0"
+scikit-learn = ">=1.0.0"
 packaging = ">=0.21,<22.0"
 
 [tool.poetry.dev-dependencies]
-tensorflow = ">=2.4.0"
+tensorflow = ">=2.7.0"
 coverage = {extras = ["toml"], version = ">=5.4"}
 dataclasses = {version = "^0.8", python = "<3.7"}
 insipid-sphinx-theme = ">=0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ license = "MIT"
 name = "scikeras"
 readme = "README.md"
 repository = "https://github.com/adriangb/scikeras"
-version = "0.4.1"
+version = "0.5.0"
 
 [tool.poetry.dependencies]
 importlib-metadata = {version = "^3", python = "<3.8"}
-python = ">=3.6.1,<3.10.0"
+python = ">=3.7.0,<3.10.0"
 scikit-learn = ">=1.0.0"
 packaging = ">=0.21,<22.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",

--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -30,6 +30,7 @@ from scikeras import _saving_utils
 
 
 _keras.Model.__reduce__ = _saving_utils.pack_keras_model
+_keras.Model.__deepcopy__ = _saving_utils.deepcopy_model
 _keras.losses.Loss.__reduce__ = _saving_utils.pack_keras_loss
 _keras.metrics.Metric.__reduce__ = _saving_utils.pack_keras_metric
 _keras.optimizers.Optimizer.__reduce__ = _saving_utils.pack_keras_optimizer

--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -24,7 +24,7 @@ else:
     if version.parse(tf_version) < version.parse(MIN_TF_VERSION):  # pragma: no cover
         raise ImportError(TF_VERSION_ERR)
 
-from tensorflow import keras as _keras
+import tensorflow.keras as _keras
 
 from scikeras import _saving_utils
 

--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:
 __version__ = importlib_metadata.version("scikeras")
 
 
-MIN_TF_VERSION = "2.4.0"
+MIN_TF_VERSION = "2..7.0"
 TF_VERSION_ERR = f"SciKeras requires TensorFlow >= {MIN_TF_VERSION}."
 
 from packaging import version

--- a/scikeras/__init__.py
+++ b/scikeras/__init__.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:
 __version__ = importlib_metadata.version("scikeras")
 
 
-MIN_TF_VERSION = "2..7.0"
+MIN_TF_VERSION = "2.7.0"
 TF_VERSION_ERR = f"SciKeras requires TensorFlow >= {MIN_TF_VERSION}."
 
 from packaging import version

--- a/scikeras/_saving_utils.py
+++ b/scikeras/_saving_utils.py
@@ -7,10 +7,10 @@ from types import MethodType
 from typing import Any, Callable, Dict, Iterable, List, Tuple
 
 import numpy as np
+import tensorflow.keras as keras
 
 from tensorflow import Variable
 from tensorflow import io as tf_io
-from tensorflow import keras
 from tensorflow.keras.models import load_model
 
 

--- a/scikeras/_saving_utils.py
+++ b/scikeras/_saving_utils.py
@@ -4,7 +4,7 @@ import tempfile
 
 from io import BytesIO
 from types import MethodType
-from typing import Any, Callable, Dict, Iterable, List, Tuple
+from typing import Any, Callable, Dict, Hashable, Iterable, List, Tuple
 
 import numpy as np
 import tensorflow.keras as keras
@@ -111,6 +111,13 @@ def pack_keras_model(
         unpack_keras_model,
         (model_bytes, optimizer_weights),
     )
+
+
+def deepcopy_model(model: keras.Model, memo: Dict[Hashable, Any]) -> keras.Model:
+    _, (model_bytes, optimizer_weights) = pack_keras_model(model)
+    new_model = unpack_keras_model(model_bytes, optimizer_weights)
+    memo[model] = new_model
+    return new_model
 
 
 def unpack_keras_optimizer(

--- a/scikeras/_utils.py
+++ b/scikeras/_utils.py
@@ -1,60 +1,66 @@
 import inspect
 import os
 import random
-import warnings
 
+from contextlib import contextmanager
 from types import FunctionType
-from typing import Any, Callable, Dict, Iterable, Mapping, Sequence, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    Mapping,
+    Sequence,
+    Type,
+    Union,
+)
 
 import numpy as np
 import tensorflow as tf
 
-from numpy.lib.arraysetops import isin
 from tensorflow.keras import losses as losses_mod
 from tensorflow.keras import metrics as metrics_mod
 from tensorflow.keras import optimizers as optimizers_mod
+from tensorflow.python.eager import context
+from tensorflow.python.framework import config, ops
 
 
 DIGITS = frozenset(str(i) for i in range(10))
 
 
-class TFRandomState:
-    def __init__(self, seed):
-        self.seed = seed
-        self._not_found = object()
+@contextmanager
+def tensorflow_random_state(seed: int) -> Generator[None, None, None]:
+    # Save values
+    origin_gpu_det = os.environ.get("TF_DETERMINISTIC_OPS", None)
+    orig_random_state = random.getstate()
+    orig_np_random_state = np.random.get_state()
+    if context.executing_eagerly():
+        tf_random_seed = context.global_seed()
+    else:
+        tf_random_seed = ops.get_default_graph().seed
 
-    def __enter__(self):
-        warnings.warn(
-            "Setting the random state for TF involves "
-            "irreversibly re-setting the random seed. "
-            "This may have unintended side effects."
-        )
+    determism_enabled = config.is_op_determinism_enabled()
+    config.enable_op_determinism()
 
-        # Save values
-        self.origin_hashseed = os.environ.get("PYTHONHASHSEED", self._not_found)
-        self.origin_gpu_det = os.environ.get("TF_DETERMINISTIC_OPS", self._not_found)
-        self.orig_random_state = random.getstate()
-        self.orig_np_random_state = np.random.get_state()
+    # Set values
+    os.environ["TF_DETERMINISTIC_OPS"] = "1"
+    random.seed(seed)
+    np.random.seed(seed)
+    tf.random.set_seed(seed)
 
-        # Set values
-        os.environ["PYTHONHASHSEED"] = str(self.seed)
-        os.environ["TF_DETERMINISTIC_OPS"] = "1"
-        random.seed(self.seed)
-        np.random.seed(self.seed)
-        tf.random.set_seed(self.seed)
+    yield
 
-    def __exit__(self, type, value, traceback):
-        if self.origin_hashseed is not self._not_found:
-            os.environ["PYTHONHASHSEED"] = self.origin_hashseed
-        else:
-            os.environ.pop("PYTHONHASHSEED")
-        if self.origin_gpu_det is not self._not_found:
-            os.environ["TF_DETERMINISTIC_OPS"] = self.origin_gpu_det
-        else:
-            os.environ.pop("TF_DETERMINISTIC_OPS")
-        random.setstate(self.orig_random_state)
-        np.random.set_state(self.orig_np_random_state)
-        tf.random.set_seed(None)  # TODO: can we revert instead of unset?
+    # Reset values
+    if origin_gpu_det is not None:
+        os.environ["TF_DETERMINISTIC_OPS"] = origin_gpu_det
+    else:
+        os.environ.pop("TF_DETERMINISTIC_OPS")
+    random.setstate(orig_random_state)
+    np.random.set_state(orig_np_random_state)
+    tf.random.set_seed(tf_random_seed)
+    if not determism_enabled:
+        config.disable_op_determinism()
 
 
 def route_params(

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -648,16 +648,6 @@ class BaseWrapper(BaseEstimator):
                         f"X has {len(X_shape_)} dimensions, but this {self.__name__}"
                         f" is expecting {len(self.X_shape_)} dimensions in X."
                     )
-                # The following check is a backport from
-                # sklearn.base.BaseEstimator._check_n_features
-                # since this method is not available in sklearn <= 0.22.0
-                if n_features_in_ != self.n_features_in_:
-                    raise ValueError(
-                        "X has {} features, but {} is expecting {} features "
-                        "as input.".format(
-                            n_features_in_, self.__class__.__name__, self.n_features_in_
-                        )
-                    )
         return X, y
 
     def _type_of_target(self, y: np.ndarray) -> str:

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -22,13 +22,13 @@ from tensorflow.keras.models import Model
 from tensorflow.keras.utils import register_keras_serializable
 
 from scikeras._utils import (
-    TFRandomState,
     accepts_kwargs,
     get_loss_class_function_or_string,
     get_metric_class,
     get_optimizer_class,
     has_param,
     route_params,
+    tensorflow_random_state,
     try_to_convert_strings_to_classes,
     unflatten_params,
 )
@@ -402,7 +402,7 @@ class BaseWrapper(BaseEstimator):
 
         # build model
         if self._random_state is not None:
-            with TFRandomState(self._random_state):
+            with tensorflow_random_state(self._random_state):
                 model = final_build_fn(**build_params)
         else:
             model = final_build_fn(**build_params)
@@ -497,7 +497,7 @@ class BaseWrapper(BaseEstimator):
         fit_args["callbacks"] = self._fit_callbacks
 
         if self._random_state is not None:
-            with TFRandomState(self._random_state):
+            with tensorflow_random_state(self._random_state):
                 hist = self.model_.fit(x=X, y=y, **fit_args)
         else:
             hist = self.model_.fit(x=X, y=y, **fit_args)
@@ -1281,8 +1281,6 @@ class KerasClassifier(BaseWrapper):
             sparse tensors",
             "check_no_attributes_set_in_init": "can only \
             pass if all params are hardcoded in __init__",
-            "check_class_weight_classifiers": "fails without \
-            >20 epochs, tested seperately",
         },
         **BaseWrapper._tags,
     }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,6 @@
 """Unit test package for scikeras."""
 import pytest
-
-from sklearn.exceptions import DataConversionWarning  # noqa
+import tensorflow as tf
 
 
 # Force data conversion warnings to be come errors
@@ -9,6 +8,6 @@ pytestmark = pytest.mark.filterwarnings(
     "error::sklearn.exceptions.DataConversionWarning"
 )
 
-# @pytest.mark.filterwarnings("ignore:api v1")
-# def test_one():
-#     assert api_v1() == 1
+
+# Don't filter tensorflow tracebacks
+tf.debugging.disable_traceback_filtering()

--- a/tests/multi_output_models.py
+++ b/tests/multi_output_models.py
@@ -43,7 +43,7 @@ class MultiLabelTransformer(ClassifierLabelEncoder):
         if self._target_type not in ("multilabel-indicator", "multiclass-multioutput"):
             return super().inverse_transform(y, return_proba=return_proba)
         if return_proba:
-            return y
+            return np.column_stack(y)
         if self._target_type == "multilabel-indicator":
             if self.split:
                 y = np.column_stack(y)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.datasets import load_boston, load_digits, load_iris
+from sklearn.datasets import fetch_california_housing, load_digits, load_iris
 from sklearn.ensemble import (
     AdaBoostClassifier,
     AdaBoostRegressor,
@@ -107,13 +107,13 @@ class TestBasicAPI:
     def test_regression_build_fn(self):
         """Tests for errors using KerasRegressor."""
         reg = KerasRegressor(model=build_fn_reg, hidden_dim=5)
-        basic_checks(reg, load_boston)
+        basic_checks(reg, fetch_california_housing)
 
     def test_regression_inherit_class_build_fn(self):
         """Tests for errors using KerasRegressor inherited."""
 
         reg = InheritClassBuildFnReg(model=None, hidden_dim=5,)
-        basic_checks(reg, load_boston)
+        basic_checks(reg, fetch_california_housing)
 
 
 def load_digits8x8():
@@ -199,7 +199,7 @@ def build_fn_clscf(
 
 CONFIG = {
     "MLPRegressor": (
-        load_boston,
+        fetch_california_housing,
         KerasRegressor,
         dynamic_regressor,
         (BaggingRegressor, AdaBoostRegressor),
@@ -384,7 +384,7 @@ class TestPrebuiltModel:
 def test_warm_start():
     """Test the warm start parameter."""
     # Load data
-    data = load_boston()
+    data = fetch_california_housing()
     X, y = data.data[:100], data.target[:100]
     # Initial fit
     estimator = KerasRegressor(
@@ -415,7 +415,7 @@ class CustomMetric(metrics_module.MeanAbsoluteError):
 
 class TestPartialFit:
     def test_partial_fit(self):
-        data = load_boston()
+        data = fetch_california_housing()
         X, y = data.data[:100], data.target[:100]
         estimator = KerasRegressor(
             model=dynamic_regressor, model__hidden_layer_sizes=[100,],
@@ -432,7 +432,7 @@ class TestPartialFit:
         assert estimator.model_ is model, "Model memory address should remain constant"
 
     def test_partial_fit_history_metric_names(self):
-        data = load_boston()
+        data = fetch_california_housing()
         X, y = data.data[:100], data.target[:100]
         estimator = KerasRegressor(
             model=dynamic_regressor,
@@ -457,7 +457,7 @@ class TestPartialFit:
         # into the history is added
         # As per https://github.com/keras-team/keras/issues/1766,
         # there is no direct measure of epochs
-        data = load_boston()
+        data = fetch_california_housing()
         X, y = data.data[:100], data.target[:100]
         estimator = KerasRegressor(
             model=dynamic_regressor,
@@ -477,7 +477,7 @@ class TestPartialFit:
         """Test that partial_fit trains for a single epoch,
         independently of what epoch value is passed to the constructor.
         """
-        data = load_boston()
+        data = fetch_california_housing()
         X, y = data.data[:100], data.target[:100]
         epochs = 9
         partial_fit_iter = 4
@@ -509,7 +509,7 @@ class TestPartialFit:
         behavior. It is tested because the epochs
         param has special handling within param routing.
         """
-        data = load_boston()
+        data = fetch_california_housing()
         X, y = data.data[:10], data.target[:10]
         epochs = 2
         partial_fit_iter = 3
@@ -623,7 +623,7 @@ class TestHistory:
     def test_history(self):
         """Test that history_'s keys are strings and values are lists.
         """
-        data = load_boston()
+        data = fetch_california_housing()
         X, y = data.data[:100], data.target[:100]
         estimator = KerasRegressor(
             model=dynamic_regressor, model__hidden_layer_sizes=[]
@@ -645,7 +645,7 @@ class TestHistory:
             model__hidden_layer_sizes=(100,),
             metrics=["mae"],  # shorthand
         )
-        X, y = load_boston(return_X_y=True)
+        X, y = fetch_california_housing(return_X_y=True)
         X = X[:100]
         y = y[:100]
         est.fit(X, y)
@@ -659,7 +659,7 @@ def test_compile_model_from_params():
     it is not re-compiled.
     """
     # Load data
-    data = load_boston()
+    data = fetch_california_housing()
     X, y = data.data[:100], data.target[:100]
 
     other_loss = losses_module.MeanAbsoluteError

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -205,10 +205,7 @@ def test_target_shape_changes_incremental_fit_clf():
 
     est = KerasClassifier(model=dynamic_classifier, hidden_layer_sizes=(100,))
     est.fit(X, y)
-    with pytest.raises(
-        ValueError,
-        match="The number of features in X is different to the number",  # raised by transformers
-    ):
+    with pytest.raises(ValueError, match="features"):  # raised by transformers
         est.partial_fit(X, np.column_stack([y, y]))
 
 

--- a/tests/test_input_outputs.py
+++ b/tests/test_input_outputs.py
@@ -410,8 +410,7 @@ def test_output_shapes_and_dtypes_against_sklearn_cls(test_data: TestParams):
         return keras_model_fit(x=x, y=y, **kwargs)
 
     with patch.object(scikeras_est.model_, "fit", new=check_dtypes):
-        with pytest.warns(UserWarning, match="Setting the random state for TF"):
-            scikeras_est.fit(X_train, y_train)
+        scikeras_est.fit(X_train, y_train)
 
     y_out_scikeras = scikeras_est.predict(X_test)
     y_out_sklearn = sklearn_est.fit(X_train, y_train).predict(X_test)

--- a/tests/test_scikit_learn_checks.py
+++ b/tests/test_scikit_learn_checks.py
@@ -1,14 +1,10 @@
 """Tests using Scikit-Learn's bundled estimator_checks."""
 
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 from typing import Any, Dict
-from unittest.mock import patch
 
-import numpy as np
 import pytest
 
-from sklearn import __version__ as sklearn_version
 from sklearn.datasets import load_iris
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
 from tensorflow.keras import Model, Sequential, layers
@@ -60,23 +56,12 @@ batch_size = 1000
             model__hidden_layer_sizes=[],
         ),
     ],
-    ids=["KerasClassifier", "KerasRegressor"],
 )
 def test_fully_compliant_estimators_low_precision(estimator, check):
     """Checks that can be passed with sklearn's default tolerances
     and in a single epoch.
     """
     check_name = check.func.__name__
-    if sklearn_version <= LooseVersion("0.23.0") and check_name in (
-        "check_classifiers_predictions",
-        "check_classifiers_classes",
-        "check_methods_subset_invariance",
-        "check_no_attributes_set_in_init",
-        "check_class_weight_classifiers",
-        "check_regressor_multioutput",
-    ):
-        # These tests have bugs that are fixed in 0.23.0
-        pytest.skip("This test is broken in sklearn<=0.23.0")
     if check_name in higher_precision:
         pytest.skip(
             "This test is run as part of test_fully_compliant_estimators_high_precision."
@@ -101,7 +86,6 @@ def test_fully_compliant_estimators_low_precision(estimator, check):
             epochs=20,
         ),
     ],
-    ids=["KerasClassifier", "KerasRegressor"],
 )
 def test_fully_compliant_estimators_high_precision(estimator, check):
     """Checks that require higher training epochs.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -7,7 +7,7 @@ import pytest
 import tensorflow as tf
 
 from sklearn.base import clone
-from sklearn.datasets import load_boston, make_regression
+from sklearn.datasets import fetch_california_housing, make_regression
 from tensorflow import keras
 from tensorflow.keras.layers import Dense, Input
 from tensorflow.keras.models import Model
@@ -55,7 +55,7 @@ def test_custom_loss_function():
     estimator = KerasRegressor(
         model=dynamic_regressor, loss=CustomLoss(), model__hidden_layer_sizes=(100,),
     )
-    check_pickle(estimator, load_boston)
+    check_pickle(estimator, fetch_california_housing)
 
 
 # ---------------------- Subclassed Model Tests ------------------
@@ -87,7 +87,7 @@ def test_custom_model_registered():
     """Test that a registered subclassed Model can be serialized.
     """
     estimator = KerasRegressor(model=build_fn_custom_model_registered)
-    check_pickle(estimator, load_boston)
+    check_pickle(estimator, fetch_california_housing)
 
 
 def build_fn_custom_model_unregistered(
@@ -115,7 +115,7 @@ def test_custom_model_unregistered():
     """Test that pickling an unregistered subclassed model works.
     """
     estimator = KerasRegressor(model=build_fn_custom_model_unregistered)
-    check_pickle(estimator, load_boston)
+    check_pickle(estimator, fetch_california_housing)
 
 
 # ---------------- Model Compiled with `run_eagerly` --------------------
@@ -127,7 +127,7 @@ def test_run_eagerly():
     estimator = KerasRegressor(
         model=dynamic_regressor, run_eagerly=True, model__hidden_layer_sizes=(100,),
     )
-    check_pickle(estimator, load_boston)
+    check_pickle(estimator, fetch_california_housing)
 
 
 def _weights_close(model1, model2):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -6,7 +6,6 @@ from functools import partial
 import numpy as np
 import pytest
 
-from sklearn import config_context
 from sklearn.utils.estimator_checks import (
     parametrize_with_checks as _parametrize_with_checks,
 )
@@ -29,27 +28,19 @@ def basic_checks(estimator, loader):
 
 def _get_check_estimator_ids(obj, estimator_ids=None):
     """Backport from Scikit-Learn = 0.23.0, not available in 0.22.0"""
-    if callable(obj):
-        if not isinstance(obj, partial):
-            return obj.__name__
+    if obj in estimator_ids:
+        return estimator_ids[obj]
+    if not isinstance(obj, partial):
+        return obj.__name__
 
-        if not obj.keywords:
-            return obj.func.__name__
+    if not obj.keywords:
+        return obj.func.__name__
 
-        kwstring = ",".join(["{}={}".format(k, v) for k, v in obj.keywords.items()])
-        return "{}({})".format(obj.func.__name__, kwstring)
-    if hasattr(obj, "get_params"):
-        # An estimator
-        if estimator_ids is None:
-            # Get id/string from parameters
-            with config_context(print_changed_only=True):
-                return re.sub(r"\s", "", str(obj))
-        else:
-            # User user supplied ID
-            return estimator_ids[obj]
+    kwstring = ",".join(["{}={}".format(k, v) for k, v in obj.keywords.items()])
+    return "{}({})".format(obj.func.__name__, kwstring)
 
 
-def parametrize_with_checks(estimators, ids=None):
+def parametrize_with_checks(estimators):
     """Wraps scikit-learn's fixture to allow setting IDs.
 
     This is done for 2 reasons:
@@ -63,8 +54,12 @@ def parametrize_with_checks(estimators, ids=None):
     """
     checks_generator = _parametrize_with_checks(estimators).args[1]
 
-    if ids is not None:
-        estimator_ids = {estimator: _id for _id, estimator in zip(ids, estimators)}
-        ids = partial(_get_check_estimator_ids, estimator_ids=estimator_ids)
+    estimator_ids = {
+        estimator: _id
+        for _id, estimator in zip(
+            (e.__class__.__name__ for e in estimators), estimators
+        )
+    }
+    ids = partial(_get_check_estimator_ids, estimator_ids=estimator_ids)
 
     return pytest.mark.parametrize("estimator, check", checks_generator, ids=ids)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -27,7 +27,7 @@ def basic_checks(estimator, loader):
 
 
 def _get_check_estimator_ids(obj, estimator_ids=None):
-    """Backport from Scikit-Learn = 0.23.0, not available in 0.22.0"""
+    """Backport from Scikit-Learn = 1.0.0, not available in 0.22.0"""
     if obj in estimator_ids:
         return estimator_ids[obj]
     if not isinstance(obj, partial):


### PR DESCRIPTION
This fixes compatibility with TensorFlow 2.7.0, at the cost of dropping support for older versions.