### PR TITLE
MAINT: add optional packages for tensorflow and tensorflow-cpu; update documentation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v2
-      
+
       - name: Update packages
         run: |
           pip install -U pip wheel
@@ -44,9 +44,9 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          poetry install
+          poetry install -E tensorflow
 
-      - name: Test with pytest 
+      - name: Test with pytest
         run: |
           poetry run python -m pip freeze
           poetry run python -m pytest -v --cov=scikeras --cov-report xml --color=yes
@@ -119,11 +119,10 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          poetry install
-          poetry add "tensorflow==${{matrix.tf-version}}"
+          poetry install -E tensorflow
           poetry add "scikit-learn==${{matrix.sklearn-version}}"
 
-      - name: Test with pytest 
+      - name: Test with pytest
         run: |
           poetry run python -m pip freeze
           poetry run python -m pytest -v --cov=scikeras --cov-report xml --color=yes
@@ -155,7 +154,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          poetry install
+          poetry install -E tensorflow
 
       - name: Test with pytest
         run: |

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ An overview of the advantages and differences as compared to the TF wrappers can
 This package is available on PyPi:
 
 ```bash
-pip install scikeras
+# Normal tensorflow
+pip install scikeras[tensorflow]
+
+# or tensorflow-cpu
+pip install scikeras[tensorflow-cpu]
 ```
 
 The current version of SciKeras depends on `scikit-learn>=1.0.0` and `TensorFlow>=2.7.0`.
 
-You will need to manually install TensorFlow; due to TensorFlow's packaging it is not a direct dependency of SciKeras.
-You can do this by running:
 
 ```bash
 pip install tensorflow

--- a/README.md
+++ b/README.md
@@ -26,12 +26,17 @@ pip install scikeras[tensorflow]
 pip install scikeras[tensorflow-cpu]
 ```
 
+SciKeras packages TensorFlow as an optional dependency because there are
+several flavors of TensorFlow available (`tensorflow`, `tensorflow-cpu`, etc.).
+Depending on _one_ of them in particular disallows the usage of the other, which is why
+they need to be optional.
+
+`pip install scikeras[tensorflow]` is basically equivalent to `pip install scikeras tensorflow`
+and is offered just for convenience. You can also install just SciKeras with
+`pip install scikera`s, but you will need a version of tensorflow installed at
+runtime or SciKeras will throw an error when you try to import it.
+
 The current version of SciKeras depends on `scikit-learn>=1.0.0` and `TensorFlow>=2.7.0`.
-
-
-```bash
-pip install tensorflow
-```
 
 ### Migrating from `tf.keras.wrappers.scikit_learn`
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -13,7 +13,7 @@ To install with pip, run:
 
 .. code:: bash
 
-    pip install scikeras
+    pip install scikeras[tensorflow]
 
 We recommend to use a virtual environment for this.
 

--- a/docs/source/notebooks/Benchmarks.md
+++ b/docs/source/notebooks/Benchmarks.md
@@ -35,7 +35,7 @@ SciKeras wraps Keras Models, but does not alter their performance since all of t
 try:
     import scikeras
 except ImportError:
-    !python -m pip install scikeras
+    !python -m pip install scikeras[tensorflow]
 ```
 
 Silence TensorFlow logging to keep output succinct.

--- a/docs/source/notebooks/DataTransformers.md
+++ b/docs/source/notebooks/DataTransformers.md
@@ -50,7 +50,7 @@ In this notebook, we explore how to reconcile this functionality with the sklear
 try:
     import scikeras
 except ImportError:
-    !python -m pip install scikeras
+    !python -m pip install scikeras[tensorflow]
 ```
 
 Silence TensorFlow warnings to keep output succint.

--- a/docs/source/notebooks/Meta_Estimators.md
+++ b/docs/source/notebooks/Meta_Estimators.md
@@ -35,7 +35,7 @@ In this notebook, we implement sklearn ensemble and tree meta-estimators backed 
 try:
     import scikeras
 except ImportError:
-    !python -m pip install scikeras
+    !python -m pip install scikeras[tensorflow]
 ```
 
 Silence TensorFlow logging to keep output succinct.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,10 @@ importlib-metadata = {version = "^3", python = "<3.8"}
 python = ">=3.7.0,<3.10.0"
 scikit-learn = ">=1.0.0"
 packaging = ">=0.21,<22.0"
+tensorflow = {version = "2.7.0", optional = true}
+tensorflow-cpu = {version = "2.7.0", optional = true}
 
 [tool.poetry.dev-dependencies]
-tensorflow = ">=2.7.0"
 coverage = {extras = ["toml"], version = ">=5.4"}
 dataclasses = {version = "^0.8", python = "<3.7"}
 insipid-sphinx-theme = ">=0.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,15 @@ importlib-metadata = {version = "^3", python = "<3.8"}
 python = ">=3.7.0,<3.10.0"
 scikit-learn = ">=1.0.0"
 packaging = ">=0.21,<22.0"
-tensorflow = {version = "2.7.0", optional = true}
-tensorflow-cpu = {version = "2.7.0", optional = true}
+tensorflow = {version = ">=2.7.0", optional = true}
+tensorflow-cpu = {version = ">=2.7.0", optional = true}
+
+[tool.poetry.extras]
+tensorflow = ["tensorflow"]
+tensorflow-cpu = ["tensorflow-cpu"]
 
 [tool.poetry.dev-dependencies]
+tensorflow = ">=2.7.0"
 coverage = {extras = ["toml"], version = ">=5.4"}
 dataclasses = {version = "^0.8", python = "<3.7"}
 insipid-sphinx-theme = ">=0.2.2"


### PR DESCRIPTION
# Description

Fixes #261 


# Changes

```
poetry add --optional tensorflow==2.7.0
poetry add --optional tensorflow==2.7.0
```

Update documentation. I updated all pip install sites - but maybe only some need to be updated?