### PR TITLE
Add sklearn mixin inheritance

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Set, Tuple, Typ
 import numpy as np
 import tensorflow as tf
 
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score as sklearn_accuracy_score
 from sklearn.metrics import r2_score as sklearn_r2_score
@@ -1158,7 +1158,7 @@ class BaseWrapper(BaseEstimator):
         return repr_
 
 
-class KerasClassifier(BaseWrapper):
+class KerasClassifier(BaseWrapper, ClassifierMixin):
     """Implementation of the scikit-learn classifier API for Keras.
 
     Below are a list of SciKeras specific parameters. For details on other parameters,
@@ -1531,7 +1531,7 @@ class KerasClassifier(BaseWrapper):
         return y
 
 
-class KerasRegressor(BaseWrapper):
+class KerasRegressor(BaseWrapper, RegressorMixin):
     """Implementation of the scikit-learn classifier API for Keras.
 
     Below are a list of SciKeras specific parameters. For details on other parameters,

--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Set, Tuple, Typ
 import numpy as np
 import tensorflow as tf
 
-from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score as sklearn_accuracy_score
 from sklearn.metrics import r2_score as sklearn_r2_score


### PR DESCRIPTION
Sklearn interface presumes the estimators inherit from RegressorMixin and ClassifierMixin. It doesn't accually add any useful functionality, but it allows one to check, what interface do the class implement

`isinstance(model, RegressorMixin)`

It is useful to check this in your code to know if e.g. the class implements predict_proba and how do predict work (give some continuous scores or discrete predictions).