### PR TITLE
Allow functools.partial in wrappers.py

### DIFF
--- a/scikeras/wrappers.py
+++ b/scikeras/wrappers.py
@@ -1,5 +1,6 @@
 """Wrapper for using the Scikit-Learn API with Keras models.
 """
+import functools
 import inspect
 import warnings
 
@@ -313,7 +314,7 @@ class BaseWrapper(BaseEstimator):
             def final_build_fn():
                 return model
 
-        elif inspect.isfunction(model):
+        elif inspect.isfunction(model) or isinstance(model, functools.partial):
             if hasattr(self, "_keras_build_fn"):
                 raise ValueError(
                     "This class cannot implement ``_keras_build_fn`` if"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 """Tests for Scikit-learn API wrapper."""
-from functools import partial
 import pickle
 
+from functools import partial
 from typing import Any, Dict, Sequence
 
 import numpy as np
@@ -873,6 +873,7 @@ class TestInitialize:
         np.testing.assert_allclose(y_pred_keras, y_pred_scikeras)
         # Check that we are still using the same model object
         assert est.model_ is m2
+
 
 def build_model_for_partial_wrapping(input_size: int = 100) -> keras.Model:
     inp = keras.layers.Input((input_size,))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,8 @@
 """Tests for Scikit-learn API wrapper."""
+from functools import partial
 import pickle
 
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import numpy as np
 import pytest
@@ -872,3 +873,20 @@ class TestInitialize:
         np.testing.assert_allclose(y_pred_keras, y_pred_scikeras)
         # Check that we are still using the same model object
         assert est.model_ is m2
+
+def build_model_for_partial_wrapping(input_size: int = 100) -> keras.Model:
+    inp = keras.layers.Input((input_size,))
+    out = keras.layers.Dense(1)(inp)
+    return keras.Model(inp, out)
+
+
+def test_partial_model_build_fn() -> None:
+    X = np.random.random((100, 1))
+    y = np.random.uniform(low=0, high=3, size=(100,))
+
+    build_fn = partial(build_model_for_partial_wrapping, input_size=1)
+
+    clf = KerasClassifier(build_fn)
+    clf = clf.fit(X, y)
+    clf = pickle.loads(pickle.dumps(clf))
+    clf.predict(X)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -888,6 +888,6 @@ def test_partial_model_build_fn() -> None:
     build_fn = partial(build_model_for_partial_wrapping, input_size=1)
 
     reg = KerasRegressor(build_fn, loss="mse")
-    dev = dev.fit(X, y)
+    reg = reg.fit(X, y)
     reg = pickle.loads(pickle.dumps(reg))
     reg.predict(X)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -887,7 +887,7 @@ def test_partial_model_build_fn() -> None:
 
     build_fn = partial(build_model_for_partial_wrapping, input_size=1)
 
-    clf = KerasClassifier(build_fn)
-    clf = clf.fit(X, y)
-    clf = pickle.loads(pickle.dumps(clf))
-    clf.predict(X)
+    reg = KerasRegressor(build_fn, loss="mse")
+    dev = dev.fit(X, y)
+    reg = pickle.loads(pickle.dumps(reg))
+    reg.predict(X)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 import pickle
 
 from functools import partial
-from typing import Any, Dict, Sequence
+from typing import Any, Dict
 
 import numpy as np
 import pytest


### PR DESCRIPTION
Allow for model instantiation functions which are built using functools.partial.

I imagine this is a common use case, where model functions might need to have certain parameters set using functools.partial. In that case, inspect.function() returns False, and this extra check is required.

Thanks for the awesome package, super useful!!!