### PR TITLE
poetry: update tensorflow-io-gcs-filesystem version to <=0.37.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ pytest = ">=7.1.2"
 pytest-cov = ">=3.0.0"
 sphinx = ">=5.0.2"
 tensorflow = ">=2.16.1"
-tensorflow-io-gcs-filesystem = { version = "<=0.31.0", markers = "python_version < '3.12' and sys_platform == 'win32'" }
+tensorflow-io-gcs-filesystem = { version = "<=0.37.1", markers = "python_version < '3.12' and sys_platform == 'win32'" }
 
 [tool.ruff]
 select = [


### PR DESCRIPTION
Required to run `poetry install` successfully on macOS & Python 3.11